### PR TITLE
fix: test coverage reports with nyc

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -1,7 +1,7 @@
 {
-  "reporter": ["text", "lcov"],
-  "extension": [".ts"],
+  "extends": "@istanbuljs/nyc-config-typescript",
+  "all": true,
   "include": ["src/**/*.ts"],
-  "exclude": ["**/*.test.ts", "src/tests/**", "src/index.ts"],
-  "all": true
+  "exclude": ["src/tests/**/*.ts"],
+  "extension": [".ts"]
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "test:simple:single": "mocha --loader=ts-node/esm --exit --timeout 60000",
     "test:single": "mocha --loader=ts-node/esm --require $(pwd)/src/tests/setup.ts --exit --timeout 60000",
     "test:ci": "yarn test --reporter mocha-multi-reporters --reporter-options configFile=mocha-reporter-config.json",
-    "test:coverage": "nyc yarn test"
+    "test:coverage": "nyc --nycrc-path .nycrc mocha --loader=ts-node/esm --require $(pwd)/src/tests/setup.ts --exit --timeout 60000 'src/**/*.test.ts' --recursive"
   },
   "dependencies": {
     "decimal.js-light": "^2.5.1",
@@ -42,6 +42,7 @@
     "rxjs": "^7.8.1"
   },
   "devDependencies": {
+    "@istanbuljs/nyc-config-typescript": "^1.0.2",
     "@types/chai": "^5.0.0",
     "@types/mocha": "^10.0.9",
     "@types/node": "^22.7.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -194,6 +194,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@centrifuge/sdk@workspace:."
   dependencies:
+    "@istanbuljs/nyc-config-typescript": "npm:^1.0.2"
     "@types/chai": "npm:^5.0.0"
     "@types/mocha": "npm:^10.0.9"
     "@types/node": "npm:^22.7.8"
@@ -372,6 +373,17 @@ __metadata:
     js-yaml: "npm:^3.13.1"
     resolve-from: "npm:^5.0.0"
   checksum: 10c0/dd2a8b094887da5a1a2339543a4933d06db2e63cbbc2e288eb6431bd832065df0c099d091b6a67436e71b7d6bf85f01ce7c15f9253b4cbebcc3b9a496165ba42
+  languageName: node
+  linkType: hard
+
+"@istanbuljs/nyc-config-typescript@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@istanbuljs/nyc-config-typescript@npm:1.0.2"
+  dependencies:
+    "@istanbuljs/schema": "npm:^0.1.2"
+  peerDependencies:
+    nyc: ">=15"
+  checksum: 10c0/0a8ba7e46046e263cdb4d2a91c5e843de0d7b46a7cd613ca164e6d7bf120c43e9209922b9ab3b816331d3703da66f8986cbd90639c2c558ce649bbe15ecb029a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- This template is a starting point for creating a pull request. Not every pull request requires thorough documentation so use your best judgement. Typically, the higher the impact, the more documentation that is warranted. Feel free to remove sections that are not applicable to the pull request or use any combination of sections that make sense. -->

### Description

<!-- Describe the goal of this pull request and if possible, insight on the implementation choices. -->

This pull request fixes the coverage reports as they were only picking up to files under /src/
https://app.codecov.io/gh/centrifuge/sdk?search=&displayType=list

<!-- This will link the pull request to a Github issue. Remove if there is no corresponding Github issue. -->

#<issue-number>
