### PR TITLE
ci: Fix pr-check script always checking latest PR instead of current

### DIFF
--- a/.github/ci-scripts/pr-label-check.sh
+++ b/.github/ci-scripts/pr-label-check.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# Check if PR number is provided
+if [ -z "$1" ]; then
+  echo "Error: PR number is required."
+  exit 1
+fi
+
+PR_NUMBER="$1"
+
 # Function to check if a specific label exists in a list
 contains_label() {
   local label="$1"
@@ -12,11 +20,8 @@ contains_label() {
   return 1
 }
 
-# Fetch the most recent merged PR number
-LAST_PR_NUMBER=$(gh pr list --state merged --json number --jq '.[0].number')
-
 # Fetch the labels of the PR
-labels=$(gh pr view "$LAST_PR_NUMBER" --json labels --jq '.labels[].name')
+labels=$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name')
 
 # Convert labels to an array
 IFS=$'\n' read -rd '' -a label_array <<<"$labels"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -44,7 +44,7 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}      
       run: |
-        if [ "${{ github.event_name }}" == "pull_request" ]; then
+        if [ "${{ github.event_name }}" == "pull_request_review" ]; then
           PR_NUMBER=${{ github.event.pull_request.number }}
         else
           PR_NUMBER=$(gh pr list --state merged --json number --jq '.[0].number')
@@ -54,19 +54,27 @@ jobs:
         echo "::notice::PR used to check version bump: #$PR_NUMBER"
         echo "::notice::PR labels: "[${LABELS//$'\n'/,}]""
 
-        RELEASE_TYPE=$(./.github/ci-scripts/pr-label-check.sh) || exit_code=$?
-        if [ "$exit_code" -ne 0 ]; then
-          echo "::error::PR #"$PR_NUMBER" has more than one release label"
-          exit $exit_code
+        # Make script executable
+        chmod +x ./.github/ci-scripts/pr-label-check.sh
+        
+        # Run the script and capture both output and exit code
+        RELEASE_TYPE=$(./.github/ci-scripts/pr-label-check.sh $PR_NUMBER 2>&1) || {
+          # If script exits with non-zero, output the error and exit
+          echo "::error::Script failed with output: $RELEASE_TYPE"
+          exit 1
+        }
+
+        # Only proceed if we have a valid release type
+        if [ -z "$RELEASE_TYPE" ]; then
+          echo "::error::No valid release type determined"
+          exit 1
         fi
 
         echo "version=$RELEASE_TYPE" >> $GITHUB_OUTPUT
-        echo "::group::Output version"
         echo "::notice::Release type: $RELEASE_TYPE"
         if [ "$RELEASE_TYPE" == "no-release" ]; then
           echo "::notice::PR is not flagged for release, skipping other steps"
         fi        
-        echo "::endgroup::"
 
     - name: Bump version
       id: bump


### PR DESCRIPTION
<!-- This template is a starting point for creating a pull request. Not every pull request requires thorough documentation so use your best judgement. Typically, the higher the impact, the more documentation that is warranted. Feel free to remove sections that are not applicable to the pull request or use any combination of sections that make sense. -->

### Description

Due to a bug in one of the release scripts the version bump will always check the tags of the latest merged PR instead of the current PR when a PR is approved.

Fix included in PR #23 since I used it for testing