### PR TITLE
ci: remove the pre-release step

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -108,4 +108,6 @@ jobs:
               --generate-notes \
               --target "${GITHUB_SHA}" \
               --prerelease
+          elif [ "$RELEASE_TYPE" = "no-release" ]; then
+            echo "::notice::PR is not flagged for release, skipping release creation"
           fi

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -95,10 +95,17 @@ jobs:
           RELEASE_TYPE=$(./.github/ci-scripts/pr-label-check.sh $PR_NUMBER)
           echo "::notice::Last PR merged detected: #$PR_NUMBER) with release label: $RELEASE_TYPE"
 
-          if [ "$RELEASE_TYPE" != "no-release" ]; then
+          if [ "$RELEASE_TYPE" = "alpha" ] || [ "$RELEASE_TYPE" = "patch" ]; then
             VERSION=$(node -p "require('./package.json').version")
             gh release create "v${VERSION}" \
               --title "Release v${VERSION}" \
               --generate-notes \
               --target "${GITHUB_SHA}"
+          elif [ "$RELEASE_TYPE" = "minor" ] || [ "$RELEASE_TYPE" = "major" ]; then
+            VERSION=$(node -p "require('./package.json').version")
+            gh release create "v${VERSION}" \
+              --title "Release v${VERSION}" \
+              --generate-notes \
+              --target "${GITHUB_SHA}" \
+              --prerelease
           fi

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -100,6 +100,5 @@ jobs:
             gh release create "v${VERSION}" \
               --title "Release v${VERSION}" \
               --generate-notes \
-              --prerelease \
               --target "${GITHUB_SHA}"
           fi


### PR DESCRIPTION
Relese automatically on PR merge if `alpha` or `minor`
Pre-release (needs another dev to move the release into a final release) if minor or major