### PR TITLE
ci: Trigger sdk-docs workflow

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -10,9 +10,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Send Trigger to Repo B
+      - name: Send Trigger to sdk-docs repo
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          curl -X POST -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          curl -X POST -H "Authorization: Bearer ${{ env.GITHUB_TOKEN }}" \
           -H "Accept: application/vnd.github.v3+json" \
           https://api.github.com/repos/organization/sdk-docs/dispatches \
-          -d '{"event_type": "trigger-from-apps-repo"}'
+          -d '{"event_type": "trigger-docs-update", "client_payload": {"secret": "${{ secrets.WEBHOOK_SECRET }}"}}'

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -3,7 +3,7 @@ name: Trigger Docs update
 on:
   push:
     branches:
-      - main
+      - trigger-docs
 
 jobs:
   trigger:
@@ -16,5 +16,5 @@ jobs:
         run: |
           curl -X POST -H "Authorization: Bearer ${{ env.GITHUB_TOKEN }}" \
           -H "Accept: application/vnd.github.v3+json" \
-          https://api.github.com/repos/organization/documentation/dispatches \
+          https://api.github.com/repos/centrifuge/documentation/dispatches \
           -d '{"event_type": "trigger-docs-update", "client_payload": {"secret": "${{ secrets.WEBHOOK_SECRET }}"}}'

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -16,5 +16,5 @@ jobs:
         run: |
           curl -X POST -H "Authorization: Bearer ${{ env.GITHUB_TOKEN }}" \
           -H "Accept: application/vnd.github.v3+json" \
-          https://api.github.com/repos/organization/sdk-docs/dispatches \
+          https://api.github.com/repos/organization/documentation/dispatches \
           -d '{"event_type": "trigger-docs-update", "client_payload": {"secret": "${{ secrets.WEBHOOK_SECRET }}"}}'

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -1,43 +1,18 @@
-# This workflow will update the docs in the sdk-docs repo
-
-name: Update Docs
+name: Trigger Docs update
 
 on:
   push:
     branches:
-      - none
+      - main
 
 jobs:
-  update-docs:
+  trigger:
     runs-on: ubuntu-latest
+
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
-      - name: Setup Yarn
+      - name: Send Trigger to Repo B
         run: |
-          corepack enable
-          corepack prepare yarn@4.5.0 --activate
-
-      - name: Install dependencies
-        run: yarn install
-
-      - name: Run gen:docs command
-        run: yarn gen:docs
-
-      - name: Install dependencies
-        run: yarn add simple-git
-
-      - name: Setup GitHub CLI
-        run: |
-          gh auth login --with-token <<< "${{ secrets.GITHUB_TOKEN }}"
-
-      - name: Update docs
-        env:
-          PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
-        run: node ./.github/ci-scripts/update-sdk-docs.cjs
+          curl -X POST -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          https://api.github.com/repos/organization/sdk-docs/dispatches \
+          -d '{"event_type": "trigger-from-apps-repo"}'


### PR DESCRIPTION
# Move SDK Documentation Generation

Moves the SDK documentation update workflow to the sdk-docs repository for better security and maintainability.

## Key Changes
- Removed git operations from our codebase (now handled by sdk-docs repository)
- Added repository_dispatch trigger to update docs using the sdk-docs workflow 