### PR TITLE
Fix: deployment per network and assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@centrifuge/sdk",
-  "version": "0.0.0-alpha.55",
+  "version": "0.0.0-alpha.56",
   "description": "",
   "homepage": "https://github.com/centrifuge/sdk/tree/main#readme",
   "author": "",

--- a/src/Centrifuge.ts
+++ b/src/Centrifuge.ts
@@ -484,9 +484,22 @@ export class Centrifuge {
     return this._query(null, () =>
       combineLatest([this.id(spokeChainId), this.id(hubChainId)]).pipe(
         switchMap(([spokeCentId, hubCentId]) =>
-          this._queryIndexer(
+          this._queryIndexer<{
+            assetRegistrations: {
+              items: {
+                assetId: string
+                asset: {
+                  centrifugeId: string
+                  address: HexString
+                  name: string
+                  symbol: string
+                  decimals: number
+                } | null
+              }[]
+            }
+          }>(
             `query ($hubCentId: String!) {
-              assetRegistrations(where: { centrifugeId: $hubCentId }) {
+              assetRegistrations(where: { centrifugeId: $hubCentId }, limit: 1000) {
                 items {
                   assetId
                   asset {
@@ -499,21 +512,9 @@ export class Centrifuge {
                 }
               }
             }`,
-            { hubCentId: String(hubCentId) },
-            (data: {
-              assetRegistrations: {
-                items: {
-                  assetId: string
-                  asset: {
-                    centrifugeId: string
-                    address: HexString
-                    name: string
-                    symbol: string
-                    decimals: number
-                  } | null
-                }[]
-              }
-            }) => {
+            { hubCentId: String(hubCentId) }
+          ).pipe(
+            map((data) => {
               return data.assetRegistrations.items
                 .filter((assetReg) => assetReg.asset && Number(assetReg.asset.centrifugeId) === spokeCentId)
                 .map((assetReg) => {
@@ -525,7 +526,7 @@ export class Centrifuge {
                     decimals: assetReg.asset!.decimals,
                   }
                 })
-            }
+            })
           )
         )
       )

--- a/src/entities/Pool.ts
+++ b/src/entities/Pool.ts
@@ -395,10 +395,6 @@ export class Pool extends Entity {
       updatedShareClasses.forEach((sc) => {
         const id = sc.id.toString()
 
-        if (!formattedMetadata.shareClasses[id]) {
-          throw new Error(`Share class ${id} not found in pool metadata`)
-        }
-
         formattedMetadata.shareClasses[id] = {
           ...formattedMetadata.shareClasses[id],
           minInitialInvestment: sc.minInvestment,

--- a/src/entities/ShareClass.ts
+++ b/src/entities/ShareClass.ts
@@ -101,16 +101,22 @@ export class ShareClass extends Entity {
         switchMap((networks) =>
           combineLatest(
             networks.map((network) =>
-              combineLatest([this._share(network.chainId), this._restrictionManager(network.chainId), of(network)])
+              combineLatest([
+                this._share(network.chainId).pipe(catchError(() => of(null))),
+                this._restrictionManager(network.chainId).pipe(catchError(() => of(null))),
+                of(network),
+              ])
             )
           )
         ),
         map((data) =>
-          data.map(([share, restrictionManager, network]) => ({
-            chainId: network.chainId,
-            shareTokenAddress: share,
-            restrictionManagerAddress: restrictionManager,
-          }))
+          data
+            .filter(([, restrictionManager]) => restrictionManager != null)
+            .map(([share, restrictionManager, network]) => ({
+              chainId: network.chainId,
+              shareTokenAddress: share!,
+              restrictionManagerAddress: restrictionManager!,
+            }))
         )
       )
     )
@@ -1533,7 +1539,7 @@ export class ShareClass extends Entity {
       this._share(chainId).pipe(
         switchMap((share) =>
           defer(async () => {
-            const address = await this._root.getClient(this.pool.chainId).readContract({
+            const address = await this._root.getClient(chainId).readContract({
               address: share,
               abi: ABI.Currency,
               functionName: 'hook',


### PR DESCRIPTION
<!-- This template is a starting point for creating a pull request. Not every pull request requires thorough documentation so use your best judgement. Typically, the higher the impact, the more documentation that is warranted. Feel free to remove sections that are not applicable to the pull request or use any combination of sections that make sense. -->

### Description

* `SC.deploymentPerNetwork()` didn't return the right data for the restriction manager
* `Centrifuge.assets()` wrongly returned the same assets when called with different chain ids
* Don't throw when updating metadata for a shareclass that wasn't in the metadata before
