### PR TITLE
ci: use the current PR instead of the latest from main on merge

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -95,7 +95,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          PR_NUMBER=$(gh pr list --state merged --json number --jq '.[0].number')
+          PR_NUMBER=${{ github.event.pull_request.number }}
           chmod +x ./.github/ci-scripts/pr-label-check.sh
           
           # Capture both stdout and stderr from the script


### PR DESCRIPTION
Fixes a bug on the release process where after merging a PR it will check the previous PR labels instead of the current one