### PR TITLE
feat: update onchain query

### DIFF
--- a/src/entities/PoolNetwork.test.ts
+++ b/src/entities/PoolNetwork.test.ts
@@ -10,6 +10,7 @@ import { context } from '../tests/setup.js'
 import { doTransaction } from '../utils/transaction.js'
 import { AssetId, PoolId, ShareClassId } from '../utils/types.js'
 import { MerkleProofManager } from './MerkleProofManager.js'
+import { OnchainPM } from './OnchainPM.js'
 import { Pool } from './Pool.js'
 import { PoolNetwork } from './PoolNetwork.js'
 import { Vault } from './Vault.js'
@@ -545,6 +546,43 @@ function createManagerDeploymentTestSubject({
     updateBalanceSheetManagers,
   }
 }
+
+describe('PoolNetwork.onchainPM', () => {
+  const onchainPMFactory = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+  const deployedPMAddress = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  function createOnchainPMTestSubject(returnedAddress: string) {
+    const publicClient = {
+      readContract: sinon.stub().resolves(returnedAddress),
+    }
+    const root = {
+      _query: (_keys: unknown, callback: () => unknown) => callback(),
+      _protocolAddresses: sinon.stub().resolves({ onchainPMFactory }),
+      getClient: sinon.stub().resolves(publicClient),
+      _transact: sinon.stub(),
+    }
+    const pool = new Pool(root as any, poolId.raw)
+    const pn = new PoolNetwork(root as any, pool, centId)
+    return { pn, publicClient }
+  }
+
+  it('returns an OnchainPM entity when the factory resolves a deployed address', async () => {
+    const { pn } = createOnchainPMTestSubject(deployedPMAddress)
+    const result = await lastValueFrom(pn.onchainPM() as unknown as Observable<OnchainPM | null>)
+    expect(result).to.be.instanceOf(OnchainPM)
+    expect((result as OnchainPM).address).to.equal(deployedPMAddress)
+  })
+
+  it('returns null when the factory resolves the zero address (not yet deployed)', async () => {
+    const { pn } = createOnchainPMTestSubject(NULL_ADDRESS)
+    const result = await lastValueFrom(pn.onchainPM() as unknown as Observable<OnchainPM | null>)
+    expect(result).to.equal(null)
+  })
+})
 
 function makeOnOffRampReceipt(manager: `0x${string}`) {
   const topics = encodeEventTopics({

--- a/src/entities/PoolNetwork.ts
+++ b/src/entities/PoolNetwork.ts
@@ -181,10 +181,7 @@ export class PoolNetwork extends Entity {
    */
   onchainPM() {
     return this._query(['onchainPM'], () =>
-      combineLatest([
-        this._root._protocolAddresses(this.centrifugeId),
-        defer(() => this._root.getClient(this.centrifugeId)),
-      ]).pipe(
+      combineLatest([this._root._protocolAddresses(this.centrifugeId), this._root.getClient(this.centrifugeId)]).pipe(
         switchMap(([{ onchainPMFactory }, client]) =>
           defer(() =>
             client.readContract({
@@ -192,7 +189,7 @@ export class PoolNetwork extends Entity {
               abi: ABI.OnchainPMFactory,
               functionName: 'getAddress',
               args: [this.pool.id.raw],
-            }) as Promise<HexString>
+            })
           ).pipe(
             map((address) =>
               address && address !== '0x0000000000000000000000000000000000000000'
@@ -306,19 +303,14 @@ export class PoolNetwork extends Entity {
    */
   onOfframpManager(scId: ShareClassId) {
     return this._query(null, () =>
-      combineLatest([
-        this._deployedOnOffRampManagers(scId),
-        this.pool.balanceSheetManagers(),
-      ]).pipe(
+      combineLatest([this._deployedOnOffRampManagers(scId), this.pool.balanceSheetManagers()]).pipe(
         map(([deployedOnOffRampManagers, balanceSheetManagers]) => {
           if (!deployedOnOffRampManagers.length) {
             throw new Error('OnOffRampManager not found')
           }
 
           const bsManagerAddresses = new Set(
-            balanceSheetManagers
-              .filter((m) => m.centrifugeId === this.centrifugeId)
-              .map((m) => m.address.toLowerCase())
+            balanceSheetManagers.filter((m) => m.centrifugeId === this.centrifugeId).map((m) => m.address.toLowerCase())
           )
           const verifiedManagers = deployedOnOffRampManagers.filter((deployed) =>
             bsManagerAddresses.has(deployed.address.toLowerCase())
@@ -349,10 +341,7 @@ export class PoolNetwork extends Entity {
   assignOnOffRampManagerPermissions(scId: ShareClassId) {
     const self = this
     return this._transact(() => {
-      return combineLatest([
-        this._deployedOnOffRampManagers(scId),
-        this.pool.balanceSheetManagers(),
-      ]).pipe(
+      return combineLatest([this._deployedOnOffRampManagers(scId), this.pool.balanceSheetManagers()]).pipe(
         switchMap(([deployedOnOffRampManager, balanceSheetManagers]) => {
           const bsManagers = new Map<string, { address: `0x${string}`; centrifugeId: number; type: string }>()
           balanceSheetManagers.forEach((manager) => {

--- a/src/entities/PoolNetwork.ts
+++ b/src/entities/PoolNetwork.ts
@@ -175,23 +175,33 @@ export class PoolNetwork extends Entity {
   /**
    * Returns the OnchainPM entity for this pool on this chain,
    * or null if one has not been deployed yet.
+   *
+   * Resolves the address via OnchainPMFactory.getAddress(poolId) — a deterministic
+   * CREATE2 lookup that returns the zero address when no PM has been deployed.
    */
   onchainPM() {
     return this._query(['onchainPM'], () =>
-      this._root
-        ._queryIndexer(
-          `query ($poolId: BigInt!, $centrifugeId: String!) {
-            onchainPMs(where: {poolId: $poolId, centrifugeId: $centrifugeId}) {
-              items {
-                address
-              }
-            }
-          }`,
-          { poolId: this.pool.id.toString(), centrifugeId: this.centrifugeId.toString() },
-          (data: { onchainPMs: { items: { address: HexString }[] } }) =>
-            (data.onchainPMs.items[0]?.address?.toLowerCase() as HexString | undefined) ?? null
+      combineLatest([
+        this._root._protocolAddresses(this.centrifugeId),
+        defer(() => this._root.getClient(this.centrifugeId)),
+      ]).pipe(
+        switchMap(([{ onchainPMFactory }, client]) =>
+          defer(() =>
+            client.readContract({
+              address: onchainPMFactory,
+              abi: ABI.OnchainPMFactory,
+              functionName: 'getAddress',
+              args: [this.pool.id.raw],
+            }) as Promise<HexString>
+          ).pipe(
+            map((address) =>
+              address && address !== '0x0000000000000000000000000000000000000000'
+                ? new OnchainPM(this._root, this, address)
+                : null
+            )
+          )
         )
-        .pipe(map((address) => (address ? new OnchainPM(this._root, this, address) : null)))
+      )
     )
   }
 


### PR DESCRIPTION
  sdk/src/entities/PoolNetwork.ts — onchainPM() rewritten
  - Removed the dead _queryIndexer call that targeted a nonexistent onchainPMs indexer entity
  - Now uses combineLatest([_protocolAddresses, getClient]) → readContract({ address: onchainPMFactory, functionName: 'getAddress', args: [pool.id.raw] }) to resolve the address deterministically via the factory
  - Returns null when the factory returns the zero address (not yet deployed)