### PR TITLE
fix: dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,17 +13,9 @@ updates:
       - 'centrifuge/apps'
 
     groups:
-      monthly-minor-patch-updates:
+      monthly-updates:
         patterns:
           - '*'
-        update-types:
-          - 'minor'
-          - 'patch'
-      major-updates:
-        patterns:
-          - '*'
-        update-types:
-          - 'major'
 
   - package-ecosystem: 'github-actions'
     directory: '/'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,12 +7,9 @@ updates:
       interval: 'monthly'
       timezone: 'Europe/Berlin'
 
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 5
 
     assignees:
-      - 'centrifuge/apps'
-
-    reviewers:
       - 'centrifuge/apps'
 
     groups:
@@ -22,24 +19,24 @@ updates:
         update-types:
           - 'minor'
           - 'patch'
-
-  - package-ecosystem: 'npm'
-    directory: '/'
-    schedule:
-      interval: 'quarterly'
-      timezone: 'Europe/Berlin'
-
-    open-pull-requests-limit: 1
-
-    assignees:
-      - 'centrifuge/apps'
-
-    reviewers:
-      - 'centrifuge/apps'
-
-    groups:
-      quarterly-major-updates:
+      major-updates:
         patterns:
           - '*'
         update-types:
           - 'major'
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'monthly'
+      timezone: 'Europe/Berlin'
+
+    open-pull-requests-limit: 5
+
+    assignees:
+      - 'centrifuge/apps'
+
+    groups:
+      github-actions-updates:
+        patterns:
+          - '*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
       interval: 'monthly'
       timezone: 'Europe/Berlin'
 
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 1
 
     assignees:
       - 'centrifuge/apps'
@@ -31,7 +31,7 @@ updates:
       interval: 'monthly'
       timezone: 'Europe/Berlin'
 
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 1
 
     assignees:
       - 'centrifuge/apps'


### PR DESCRIPTION
### Description

This pull request fixes dependabot config to target github-actions which will update the SHA pins as necessary.
