### PR TITLE
fix: token instances query order in pool share price report

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@centrifuge/sdk",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "",
   "homepage": "https://github.com/centrifuge/sdk/tree/main#readme",
   "author": "",

--- a/src/entities/Reports/PoolSharePricesReport.ts
+++ b/src/entities/Reports/PoolSharePricesReport.ts
@@ -68,7 +68,7 @@ export class PoolSharePricesReport extends Entity {
 									tokenInstanceSnapshots(
 										where: $filter
 										orderBy: "timestamp"
-										orderDirection: "asc"
+										orderDirection: "desc"
 										limit: 1000
 									) {
 										items {
@@ -148,6 +148,8 @@ export class PoolSharePricesReport extends Entity {
       }
     })
 
-    return applyGrouping(items, filter.groupBy ?? 'day', 'latest')
+    return applyGrouping(items, filter.groupBy ?? 'day', 'latest').sort(
+      (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+    )
   }
 }


### PR DESCRIPTION
### Description

This pull request changes the `tokenInstanceSnapshots` query `orderDirection` to `desc` in the PoolSharePricesReport to get the latest dates and cut off older dates if the query limit is reached. By using `asc`, once we hit the limit, the latest dates were cut off instead.
