### PR TITLE
fix: pool share prices report aggregation by removing identical row data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@centrifuge/sdk",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "",
   "homepage": "https://github.com/centrifuge/sdk/tree/main#readme",
   "author": "",

--- a/src/entities/Reports/PoolSharePricesReport.test.ts
+++ b/src/entities/Reports/PoolSharePricesReport.test.ts
@@ -38,13 +38,12 @@ describe('PoolSharePricesReport', () => {
 
   it('sums issuance across chains for the same (date, tokenId)', () => {
     const tokenId = scId.raw
-    // Three snapshots at the same timestamp from three different chains.
     const data = {
       tokenInstanceSnapshots: {
         items: [
-          { tokenId, timestamp: '1777939200000', totalIssuance: '100', tokenPrice: '1000000000000000000' },
-          { tokenId, timestamp: '1777939200000', totalIssuance: '200', tokenPrice: '1000000000000000000' },
-          { tokenId, timestamp: '1777939200000', totalIssuance: '300', tokenPrice: '1000000000000000000' },
+          { tokenId, timestamp: '1777939200000', totalIssuance: '100', tokenPrice: '1000000000000000000', triggerChainId: '1' },
+          { tokenId, timestamp: '1777939200000', totalIssuance: '200', tokenPrice: '1000000000000000000', triggerChainId: '8453' },
+          { tokenId, timestamp: '1777939200000', totalIssuance: '300', tokenPrice: '1000000000000000000', triggerChainId: '42161' },
         ],
       },
     }
@@ -58,16 +57,14 @@ describe('PoolSharePricesReport', () => {
 
   it('prefers the price from the chain with the largest issuance', () => {
     const tokenId = scId.raw
-    // First row has 0 issuance and a stale price — should be ignored in favor
-    // of the row with the largest issuance.
     const stalePrice = '900000000000000000'
     const freshPrice = '1100000000000000000'
     const data = {
       tokenInstanceSnapshots: {
         items: [
-          { tokenId, timestamp: '1777939200000', totalIssuance: '0', tokenPrice: stalePrice },
-          { tokenId, timestamp: '1777939200000', totalIssuance: '500', tokenPrice: freshPrice },
-          { tokenId, timestamp: '1777939200000', totalIssuance: '100', tokenPrice: stalePrice },
+          { tokenId, timestamp: '1777939200000', totalIssuance: '0', tokenPrice: stalePrice, triggerChainId: '143' },
+          { tokenId, timestamp: '1777939200000', totalIssuance: '500', tokenPrice: freshPrice, triggerChainId: '1' },
+          { tokenId, timestamp: '1777939200000', totalIssuance: '100', tokenPrice: stalePrice, triggerChainId: '8453' },
         ],
       },
     }
@@ -76,5 +73,29 @@ describe('PoolSharePricesReport', () => {
     const entry = report[0]!.shareClasses[tokenId]!
     expect(entry.totalIssuance.toBigInt()).to.equal(600n)
     expect(entry.price.toBigInt()).to.equal(BigInt(freshPrice))
+  })
+
+  it('dedupes duplicate rows for the same (date, chain) before summing', () => {
+    const tokenId = scId.raw
+    const price = '1000000000000000000'
+    // The indexer can emit multiple rows for the same (date, chain) — e.g. when
+    // a period boundary triggers more than once. Each chain should contribute
+    // only its largest-issuance row to the daily total.
+    const data = {
+      tokenInstanceSnapshots: {
+        items: [
+          { tokenId, timestamp: '1777939200000', totalIssuance: '500', tokenPrice: price, triggerChainId: '1' },
+          { tokenId, timestamp: '1777939200000', totalIssuance: '500', tokenPrice: price, triggerChainId: '1' },
+          { tokenId, timestamp: '1777939200000', totalIssuance: '500', tokenPrice: price, triggerChainId: '1' },
+          { tokenId, timestamp: '1777939200000', totalIssuance: '300', tokenPrice: price, triggerChainId: '8453' },
+          { tokenId, timestamp: '1777939200000', totalIssuance: '300', tokenPrice: price, triggerChainId: '8453' },
+        ],
+      },
+    }
+
+    const report = poolSharePricesReport._process(data, {}, 18)
+    const entry = report[0]!.shareClasses[tokenId]!
+    // Naive sum would be 2100; correct dedup-then-sum is 800.
+    expect(entry.totalIssuance.toBigInt()).to.equal(800n)
   })
 })

--- a/src/entities/Reports/PoolSharePricesReport.ts
+++ b/src/entities/Reports/PoolSharePricesReport.ts
@@ -10,12 +10,6 @@ import { PoolReports } from './PoolReports.js'
 import { DataReportFilter } from './types.js'
 import { applyGrouping } from './utils.js'
 
-type ShareClassAggregate = {
-  totalIssuance: bigint
-  priceSourceIssuance: bigint
-  price: bigint
-}
-
 export type SharePricesReport = {
   timestamp: string
   shareClasses: Record<
@@ -38,6 +32,7 @@ type SharePriceData = {
       timestamp: string
       totalIssuance: string
       tokenPrice: string
+      triggerChainId: string
     }[]
   }
 }
@@ -76,6 +71,7 @@ export class PoolSharePricesReport extends Entity {
 											timestamp
 											totalIssuance
 											tokenPrice
+											triggerChainId
 										}
 									}
 								}`,
@@ -103,47 +99,53 @@ export class PoolSharePricesReport extends Entity {
     filter: Pick<SharePricesReportFilter, 'groupBy'>,
     poolDecimals: number
   ): SharePricesReport {
-    // Snapshots are emitted per (tokenId, triggerChainId). For multi-network share
-    // classes there are several rows per (date, tokenId) — sum issuance across them.
-    const aggregates: Record<string, Record<HexString, ShareClassAggregate>> = {}
+    // Snapshots are emitted per (tokenId, triggerChainId, period). The indexer
+    // sometimes returns multiple rows for the same (date, tokenId, chain) — e.g.
+    // when the same period boundary triggers on more than one block. Dedupe to
+    // one row per (date, tokenId, chain) by keeping the largest issuance, then
+    // sum across chains for the (date, tokenId) total.
+    const perChain: Record<string, Record<HexString, Record<string, { issuance: bigint; price: bigint }>>> = {}
 
     data.tokenInstanceSnapshots.items.forEach((item) => {
       const date = new Date(Number(item.timestamp)).toISOString().slice(0, 10)
-      if (!aggregates[date]) {
-        aggregates[date] = {}
-      }
-
       const issuance = BigInt(item.totalIssuance)
       const price = BigInt(item.tokenPrice)
-      const existing = aggregates[date][item.tokenId]
 
-      if (!existing) {
-        aggregates[date][item.tokenId] = {
-          totalIssuance: issuance,
-          priceSourceIssuance: issuance,
-          price,
-        }
-      } else {
-        existing.totalIssuance += issuance
-        // Prefer the price from the snapshot with the largest issuance — stale
-        // chains may report 0 issuance with an outdated price.
-        if (issuance > existing.priceSourceIssuance) {
-          existing.priceSourceIssuance = issuance
-          existing.price = price
-        }
+      const byTokenId = (perChain[date] ??= {})
+      const byChain = (byTokenId[item.tokenId] ??= {})
+      const existing = byChain[item.triggerChainId]
+
+      if (!existing || issuance > existing.issuance) {
+        byChain[item.triggerChainId] = { issuance, price }
       }
     })
 
-    const items = Object.entries(aggregates).map(([timestamp, byTokenId]) => {
+    const items = Object.entries(perChain).map(([date, byTokenId]) => {
       const shareClasses: SharePricesReport[number]['shareClasses'] = {}
-      Object.entries(byTokenId).forEach(([tokenId, agg]) => {
+
+      Object.entries(byTokenId).forEach(([tokenId, byChain]) => {
+        let totalIssuance = 0n
+        let priceSourceIssuance = -1n
+        let price = 0n
+
+        Object.values(byChain).forEach((row) => {
+          totalIssuance += row.issuance
+          // Prefer the price from the chain with the largest issuance — stale
+          // chains may report 0 issuance with an outdated price.
+          if (row.issuance > priceSourceIssuance) {
+            priceSourceIssuance = row.issuance
+            price = row.price
+          }
+        })
+
         shareClasses[tokenId as HexString] = {
-          price: new Price(agg.price),
-          totalIssuance: new Balance(agg.totalIssuance, poolDecimals),
+          price: new Price(price),
+          totalIssuance: new Balance(totalIssuance, poolDecimals),
         }
       })
+
       return {
-        timestamp: new Date(timestamp).toISOString(),
+        timestamp: new Date(date).toISOString(),
         shareClasses,
       }
     })


### PR DESCRIPTION
### Description

This pull request fixes an issue when indexer data returns multiple identical rows in tokenInstanceSnapshots.

Snapshots are emitted per (tokenId, triggerChainId, period). The indexer sometimes returns multiple rows for the same (date, tokenId, chain) — e.g. when the same period boundary triggers on more than one block. Dedupe to one row per (date, tokenId, chain) by keeping the largest issuance, then sum across chains for the (date, tokenId) total.