### PR TITLE
feat: add $onchainPM as alias for $executor magic variable

### DIFF
--- a/src/utils/variables.test.ts
+++ b/src/utils/variables.test.ts
@@ -25,15 +25,16 @@ const POOL_META = {
 
 describe('utils/variables', () => {
   describe('MAGIC_VARIABLE_KEYS', () => {
-    it('contains exactly the seven expected keys', () => {
+    it('contains exactly the eight expected keys', () => {
       expect(MAGIC_VARIABLE_KEYS).to.include('$executor')
+      expect(MAGIC_VARIABLE_KEYS).to.include('$onchainPM')
       expect(MAGIC_VARIABLE_KEYS).to.include('$poolEscrow')
       expect(MAGIC_VARIABLE_KEYS).to.include('$onOffRamp')
       expect(MAGIC_VARIABLE_KEYS).to.include('$poolId')
       expect(MAGIC_VARIABLE_KEYS).to.include('$scId')
       expect(MAGIC_VARIABLE_KEYS).to.include('$accountingTokenId')
       expect(MAGIC_VARIABLE_KEYS).to.include('$accountingTokenAssetId')
-      expect(MAGIC_VARIABLE_KEYS).to.have.length(7)
+      expect(MAGIC_VARIABLE_KEYS).to.have.length(8)
     })
 
     it('every key starts with $', () => {
@@ -44,9 +45,10 @@ describe('utils/variables', () => {
   })
 
   describe('resolveMagicVariables', () => {
-    it('maps all seven keys into a PoolContext', () => {
+    it('maps all eight keys into a PoolContext', () => {
       const ctx = resolveMagicVariables(CTX)
       expect(ctx['$executor']).to.equal(CTX.executor)
+      expect(ctx['$onchainPM']).to.equal(CTX.executor)
       expect(ctx['$poolEscrow']).to.equal(CTX.poolEscrow)
       expect(ctx['$onOffRamp']).to.equal(CTX.onOffRamp)
       expect(ctx['$poolId']).to.equal(CTX.poolId)
@@ -55,9 +57,9 @@ describe('utils/variables', () => {
       expect(ctx['$accountingTokenAssetId']).to.equal(CTX.accountingTokenAssetId)
     })
 
-    it('produces exactly seven entries — no extras', () => {
+    it('produces exactly eight entries — no extras', () => {
       const ctx = resolveMagicVariables(CTX)
-      expect(Object.keys(ctx)).to.have.length(7)
+      expect(Object.keys(ctx)).to.have.length(8)
     })
 
     it('result keys match MAGIC_VARIABLE_KEYS', () => {

--- a/src/utils/variables.ts
+++ b/src/utils/variables.ts
@@ -15,6 +15,7 @@ import type { PoolContext } from './weiroll.js'
  */
 export const MAGIC_VARIABLE_KEYS = [
   '$executor',
+  '$onchainPM',
   '$poolEscrow',
   '$onOffRamp',
   '$poolId',
@@ -98,6 +99,9 @@ export function resolveMagicVariables(context: MagicVariableContext): PoolContex
 
   return {
     $executor: context.executor,
+    // $onchainPM is an alias for $executor — the current "executor" used by
+    // workflows is always an OnchainPM instance. Templates may use either key.
+    $onchainPM: context.executor,
     $poolEscrow: context.poolEscrow,
     $onOffRamp: context.onOffRamp,
     $poolId: context.poolId,


### PR DESCRIPTION
## Summary

The current \"executor\" in workflows is always an `OnchainPM` instance. Let workflow templates use the more descriptive `\$onchainPM` key instead of (or alongside) `\$executor`. Both resolve to the same address via `resolveMagicVariables`.

Why: templates in `centrifuge/workflows` reference `\$onchainPM` to make the semantic intent clearer. Without this change the SDK treats `\$onchainPM` as a runtime variable, leaving its slot unfilled and breaking workflows (e.g. the bUSD subscribe workflow sends USDC to the wrong receiver address).

## Test plan

- [x] `MAGIC_VARIABLE_KEYS` now has 8 entries including `\$onchainPM`
- [x] `resolveMagicVariables(ctx)['\$onchainPM']` equals `ctx.executor`
- [x] Tests updated to assert both keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)