### PR TITLE
fix: length-prefix callback script slot and encode empty bytes literal as 32 zeros

### DIFF
--- a/src/utils/catalog.test.ts
+++ b/src/utils/catalog.test.ts
@@ -500,8 +500,25 @@ describe('utils/catalog', () => {
 
     expect(definition.actions[1]!.rawMode).to.equal(undefined)
     expect(bytesInput).to.equal(0x80 | bytesSlot)
-    expect(definition.state[bytesSlot]).to.deep.equal({ type: 'literal', value: '0x' })
+    // The natural empty-bytes literal `0x` must materialize as a 32-byte zero
+    // word so weiroll's CommandBuilder.setupDynamicVariable accepts it. A raw
+    // 0-byte state slot reverts at execute time with "Dynamic state variables
+    // must be a multiple of 32 bytes".
+    expect(definition.state[bytesSlot]).to.deep.equal({ type: 'literal', value: `0x${'00'.repeat(32)}` })
     expect(definition.state.every((s) => s.type !== 'rawcalldata')).to.equal(true)
+
+    // Build the script and confirm every pinned state slot is a non-zero
+    // multiple of 32 bytes — the invariant weiroll enforces on-chain.
+    const { state, stateBitmap } = buildScript(definition, {
+      poolContext: { $onchainPM: ONCHAIN_PM_BYTES32 },
+      configurableValues: {},
+    })
+    for (const [i, slot] of state.entries()) {
+      if (((stateBitmap >> BigInt(i)) & 1n) === 0n) continue
+      const byteLen = (slot.length - 2) / 2
+      expect(byteLen, `state[${i}] = ${slot} must be non-zero`).to.be.greaterThan(0)
+      expect(byteLen % 32, `state[${i}] length ${byteLen} must be a multiple of 32`).to.equal(0)
+    }
   })
 
   it('allows bytes-valued helper actions to return values for downstream use', () => {

--- a/src/utils/catalog.test.ts
+++ b/src/utils/catalog.test.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai'
 import { decodeAbiParameters, toFunctionSelector } from 'viem'
+import type { HexString } from '../types/index.js'
 import type { MarketplaceWorkflow } from '../types/workflow.js'
 import { buildWorkflowDefinitionFromCatalog } from './catalog.js'
 import { buildScript } from './weiroll.js'
@@ -421,7 +422,13 @@ describe('utils/catalog', () => {
       throw new Error('Expected callback slot to be a template slot')
     }
     expect(templateSlot.workflow.actions[2]!.rawMode).to.equal(undefined)
-    expect(templateSlot.workflow.state.some((slot) => slot.type === 'literal' && slot.value === '0x')).to.equal(true)
+    // The callback's `bytes data = 0x` literal must materialize as a 32-byte
+    // zero word (abi-encoded `bytes("")`), not raw `'0x'` (0 bytes). The latter
+    // trips weiroll's CommandBuilder check that dynamic state variables be a
+    // non-zero multiple of 32 bytes when the callback's supplyCollateral runs.
+    expect(
+      templateSlot.workflow.state.some((slot) => slot.type === 'literal' && slot.value === `0x${'00'.repeat(32)}`)
+    ).to.equal(true)
     expect(definition.runtimeVariables).to.deep.equal(['amount'])
 
     const { state, stateBitmap } = buildScript(definition, {
@@ -430,13 +437,31 @@ describe('utils/catalog', () => {
     })
     expect((stateBitmap & (1n << BigInt(callbackSlot))) !== 0n).to.equal(true)
 
+    // weiroll's CommandBuilder copies state[idx] verbatim into the parent's
+    // calldata at the bytes-input offset, without writing a length-prefix word.
+    // The first 32 bytes of state[callbackSlot] must therefore BE the length,
+    // and the remainder must abi-decode to (bytes32[], bytes[], uint128).
+    const callbackSlotData = state[callbackSlot]!
+    const callbackBytes = `0x${callbackSlotData.slice(2 + 64)}` as HexString
+    const declaredLength = Number(BigInt(`0x${callbackSlotData.slice(2, 2 + 64)}`))
+    expect(declaredLength).to.equal((callbackBytes.length - 2) / 2)
     const [commands, callbackState, callbackStateBitmap] = decodeAbiParameters(
       [{ type: 'bytes32[]' }, { type: 'bytes[]' }, { type: 'uint128' }],
-      state[callbackSlot]!
+      callbackBytes
     )
     expect(commands).to.have.length(3)
     expect(callbackState).to.include(ONCHAIN_PM_BYTES32)
     expect(typeof callbackStateBitmap).to.equal('bigint')
+    // Every PINNED state slot must be a non-zero multiple of 32 bytes —
+    // weiroll's CommandBuilder.setupDynamicVariable enforces this at execute
+    // time, so violations here would only surface as opaque on-chain reverts.
+    // Runtime slots (bit = 0) are filled later via fillRuntimeSlots.
+    for (const [i, slot] of state.entries()) {
+      if (((stateBitmap >> BigInt(i)) & 1n) === 0n) continue
+      const byteLen = (slot.length - 2) / 2
+      expect(byteLen, `state[${i}] = ${slot} must be non-zero`).to.be.greaterThan(0)
+      expect(byteLen % 32, `state[${i}] length ${byteLen} must be a multiple of 32`).to.equal(0)
+    }
   })
 
   it('keeps empty bytes literals with computed returns on the standard dynamic path', () => {

--- a/src/utils/catalog.ts
+++ b/src/utils/catalog.ts
@@ -104,8 +104,12 @@ function applyUseTemplateMap(actions: CatalogAction[], variableMap: Record<strin
       // Callback templates are compiled into one pinned bytes slot. Empty configurable
       // bytes inputs cannot be configured separately by the outer workflow, and the
       // current callback use case is Morpho's no-op `bytes data = 0x`.
+      // An empty bytes literal must be encoded as a 32-byte zero word — the
+      // abi-encoded form of `bytes("")`. The raw `'0x'` literal lands as a
+      // 0-byte state slot and trips weiroll's CommandBuilder check that
+      // dynamic state variables be a non-zero multiple of 32 bytes.
       ...(input.configurable && input.parameter === 'bytes' && (input.input ?? []).length === 0
-        ? { configurable: false, input: ['0x'] }
+        ? { configurable: false, input: [`0x${'00'.repeat(32)}`] }
         : { input: (input.input ?? []).map((value) => mapTemplateReference(value, variableMap)) }),
     })),
   }))

--- a/src/utils/catalog.ts
+++ b/src/utils/catalog.ts
@@ -23,7 +23,14 @@ const MAGIC_KEY_SET = new Set<string>(MAGIC_VARIABLE_KEYS)
  */
 function encodeLiteralValue(raw: string, parameter = ''): HexString {
   if (parameter === 'bytes') {
-    if (/^0x(?:[0-9a-fA-F]{2})*$/.test(raw)) return raw as HexString
+    if (/^0x(?:[0-9a-fA-F]{2})*$/.test(raw)) {
+      // weiroll's CommandBuilder.setupDynamicVariable requires dynamic state
+      // variables to be a non-zero multiple of 32 bytes. The natural empty-bytes
+      // literal `0x` is 0 bytes long and trips that check at execute time.
+      // Encode it as a 32-byte zero word — the abi-encoded form of `bytes("")`.
+      if (raw.length === 2) return `0x${'00'.repeat(32)}` as HexString
+      return raw as HexString
+    }
     throw new Error(`buildWorkflowDefinitionFromCatalog: unsupported bytes literal "${raw}"`)
   }
 

--- a/src/utils/weiroll.ts
+++ b/src/utils/weiroll.ts
@@ -297,10 +297,23 @@ function assembleRawCalldataSlot(
 }
 
 function encodeCallbackScript(script: ScriptResult): HexString {
-  return encodeAbiParameters(
+  // weiroll's CommandBuilder copies state[idx] verbatim into the parent's
+  // calldata at the bytes-input offset, without writing a length-prefix word.
+  // For the receiver's `bytes calldata` parameter to decode correctly, the
+  // state slot must already begin with the 32-byte length word — i.e. it must
+  // be the abi-encoded bytes representation, not just the inner payload.
+  //
+  // Wrap the abi-encoded callback tuple with a length prefix so that
+  //   bytes-input encoding produced by CommandBuilder = [length][tuple bytes]
+  // and the receiver (FlashLoanHelper.executeOperation, or any other
+  // callback dispatcher) can `abi.decode(params, ...)` directly.
+  const tuple = encodeAbiParameters(
     [{ type: 'bytes32[]' }, { type: 'bytes[]' }, { type: 'uint128' }],
     [script.commands, script.state, script.stateBitmap]
-  ) as HexString
+  )
+  const tupleBytes = (tuple.length - 2) / 2
+  const lengthWord = tupleBytes.toString(16).padStart(64, '0')
+  return `0x${lengthWord}${tuple.slice(2)}` as HexString
 }
 
 function buildTemplateSlot(


### PR DESCRIPTION
## Summary

Two related bugs in the `useTemplate` callback path that surface as opaque on-chain reverts when an outer workflow (e.g. `morpho_loop_deposit`) calls a bytes-callback target (e.g. `FlashLoanHelper.requestFlashLoan`). Both block the morpho-loop fork tests in `defi-workflows`.

## Bug 1: `encodeCallbackScript` missing length prefix

`encodeCallbackScript` returned just `abi.encode(commands, state, stateBitmap)` — the raw tuple encoding. But weiroll's `CommandBuilder` copies `state[idx]` verbatim into the parent's calldata at a `bytes`-input offset **without** prepending a length word, so the state slot must already begin with the 32-byte length.

Without the prefix the receiver's `bytes calldata params` reads the first word of the tuple (the offset to `commands`, e.g. `0x60`) as the bytes length, truncates `params` to ~96 bytes, and `abi.decode(params, ...)` reverts with empty data. Reproduced on a mainnet fork via `morpho_loop_ethereum_syrupusdc_2x_deposit`:

```
FlashLoanHelper.requestFlashLoan(...)
  → Aave.flashLoanSimple(...)
  → FlashLoanHelper.executeOperation(params) ← reverts with empty data
```

**Fix:** prepend the 32-byte length word so `state[callbackSlot]` is the abi-encoded **bytes** representation of the tuple — i.e. `[length][tuple]`.

## Bug 2: empty configurable bytes literal is 0 bytes

`applyUseTemplateMap` rewrites an empty configurable bytes input as the literal `'0x'` (0 bytes). weiroll's `CommandBuilder.setupDynamicVariable` requires dynamic state variables to be a **non-zero multiple of 32 bytes**:

```solidity
require(argLen != 0 && argLen % 32 == 0, "Dynamic state variables must be a multiple of 32 bytes");
```

With the 0-byte slot, the inner script reverts with that exact message as soon as the next command (e.g. `Morpho.supplyCollateral`) reads the bytes input.

**Fix:** encode an empty bytes literal as the 32-byte zero word (the abi-encoded form of `bytes("")`).

## Tests

The existing `injects useTemplate bytes inputs as pinned callback script data` test is updated to cover both invariants:

- the callback's empty bytes literal is now the 32-byte zero word (not `'0x'`)
- `state[callbackSlot]` starts with a valid length word, and the remainder abi-decodes to the callback tuple
- every **pinned** state slot is a non-zero multiple of 32 bytes — a generic regression catch for the `CommandBuilder` requirement that would have caught both bugs at unit-test time

Pre-existing infra failures (chain ID lookups, gas estimates, etc.) are unchanged: 209 passing / 35 failing on both `workflows-v3` and this branch.

## Test plan

- [x] Existing `injects useTemplate bytes inputs as pinned callback script data` test updated and passing
- [x] Verified the `morpho_loop_ethereum_syrupusdc_2x_deposit` fork test passes end-to-end on a mainnet anvil fork after applying the SDK patches (`SupplyCollateral`, `Borrow`, `FlashLoan` events all emit)
- [x] No new test failures vs `workflows-v3` baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)