### PR TITLE
feat: typed cross-chain adapters + messages on Pool/Centrifuge

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@centrifuge/sdk",
-  "version": "1.9.1",
+  "version": "1.10.0",
   "description": "",
   "homepage": "https://github.com/centrifuge/sdk/tree/main#readme",
   "author": "",

--- a/src/Centrifuge.test.ts
+++ b/src/Centrifuge.test.ts
@@ -188,6 +188,107 @@ describe('Centrifuge', () => {
     })
   })
 
+  describe('Cross-chain adapters and messages', () => {
+    const adapterA = '0xAAaa0000000000000000000000000000000000aa'
+    const adapterB = '0xBBbb0000000000000000000000000000000000bb'
+
+    function stubMultiAdapter(centrifuge: Centrifuge, quorum: number, threshold: number, adapters: string[]) {
+      const readContract = sinon.stub().callsFake(async ({ functionName, args }: any) => {
+        if (functionName === 'quorum') return quorum
+        if (functionName === 'threshold') return threshold
+        if (functionName === 'adapters') return adapters[Number(args[2])]
+        throw new Error(`unexpected functionName: ${functionName}`)
+      })
+      sinon.stub(centrifuge as any, '_protocolAddresses').returns(of({ multiAdapter: randomAddress() } as any))
+      sinon.stub(centrifuge as any, 'getClient').returns(of({ readContract } as any))
+    }
+
+    it('globalAdapters reads the MultiAdapter pool-0 slot and returns adapters + threshold', async () => {
+      const centrifuge = new Centrifuge({ environment: 'testnet' })
+      stubMultiAdapter(centrifuge, 2, 1, [adapterA, adapterB])
+
+      const result = await centrifuge.globalAdapters(1, 2)
+      expect(result.adapters).to.deep.equal([adapterA.toLowerCase(), adapterB.toLowerCase()])
+      expect(result.threshold).to.equal(1)
+    })
+
+    it('pool.adapters reads the MultiAdapter pool-specific slot via the same path', async () => {
+      const centrifuge = new Centrifuge({ environment: 'testnet' })
+      stubMultiAdapter(centrifuge, 1, 1, [adapterA])
+      const pool = new Pool(centrifuge, poolId.raw)
+
+      const result = await pool.adapters(2)
+      expect(result.adapters).to.deep.equal([adapterA.toLowerCase()])
+      expect(result.threshold).to.equal(1)
+    })
+
+    it('pool.messages maps indexer payloads to typed CrosschainMessages and applies status filter', async () => {
+      const centrifuge = new Centrifuge({ environment: 'testnet' })
+      const queryIndexer = sinon.stub(centrifuge as any, '_queryIndexer').returns(
+        of({
+          crosschainPayloads: {
+            totalCount: 2,
+            items: [
+              {
+                id: '0xabc',
+                index: 0,
+                fromCentrifugeId: '1',
+                toCentrifugeId: '2',
+                poolId: poolId.raw.toString(),
+                tokenId: null,
+                status: 'InTransit',
+                gasLimit: '246355',
+                gasPrice: '1200014',
+                createdAt: '1773411360000',
+                deliveredAt: null,
+                completedAt: null,
+              },
+              {
+                id: '0xdef',
+                index: 1,
+                fromCentrifugeId: '1',
+                toCentrifugeId: '3',
+                poolId: poolId.raw.toString(),
+                tokenId: '0xtoken',
+                status: 'Completed',
+                gasLimit: null,
+                gasPrice: null,
+                createdAt: '1773411360000',
+                deliveredAt: '1773411400000',
+                completedAt: '1773411500000',
+              },
+            ],
+          },
+        })
+      )
+      const pool = new Pool(centrifuge, poolId.raw)
+
+      const result = await pool.messages({ status: ['InTransit', 'Underpaid'], fromCentrifugeId: 1, limit: 10 })
+      expect(result.totalCount).to.equal(2)
+      expect(result.items).to.have.length(2)
+      expect(result.items[0]!.status).to.equal('InTransit')
+      expect(result.items[0]!.fromCentrifugeId).to.equal(1)
+      expect(result.items[0]!.toCentrifugeId).to.equal(2)
+      expect(result.items[0]!.gasLimit).to.equal(246355n)
+      expect(result.items[0]!.gasPrice).to.equal(1200014n)
+      expect(result.items[0]!.createdAt).to.be.instanceOf(Date)
+      expect(result.items[0]!.deliveredAt).to.equal(undefined)
+      expect(result.items[1]!.gasLimit).to.equal(undefined)
+      expect(result.items[1]!.deliveredAt).to.be.instanceOf(Date)
+
+      // Filter encoding: status_in for arrays, single status passed through, plus poolId always.
+      const [, vars] = queryIndexer.firstCall.args as [string, Record<string, unknown>]
+      const filter = vars.filter as Record<string, unknown>
+      expect(filter).to.deep.include({
+        poolId: poolId.raw.toString(),
+        fromCentrifugeId: '1',
+        status_in: ['InTransit', 'Underpaid'],
+      })
+      expect(filter.toCentrifugeId).to.equal(undefined)
+      expect(vars.limit).to.equal(10)
+    })
+  })
+
   describe('Query', () => {
     it('should return the first value when awaited', async () => {
       const value = await context.centrifuge._query(null, () => of(1, 2, 3))

--- a/src/Centrifuge.test.ts
+++ b/src/Centrifuge.test.ts
@@ -222,70 +222,214 @@ describe('Centrifuge', () => {
       expect(result.threshold).to.equal(1)
     })
 
-    it('pool.crosschainMessages maps indexer payloads to typed CrosschainMessages and applies status filter', async () => {
+    function basePayload(overrides: Partial<Record<string, unknown>> = {}) {
+      return {
+        id: '0xabc',
+        index: 0,
+        fromCentrifugeId: '1',
+        toCentrifugeId: '2',
+        poolId: poolId.raw.toString(),
+        tokenId: null,
+        status: 'InTransit',
+        rawData: null,
+        gasLimit: '246355',
+        gasPrice: '1200014',
+        createdAt: '1773411360000',
+        deliveredAt: null,
+        completedAt: null,
+        preparedAtTxHash: '0xprepared',
+        deliveredAtTxHash: null,
+        ...overrides,
+      }
+    }
+
+    const samplePageInfo = { hasNextPage: false, hasPreviousPage: false, startCursor: null, endCursor: null }
+
+    it('pool.crosschainMessages maps payloads, returns pageInfo, and applies status + cursor filter', async () => {
       const centrifuge = new Centrifuge({ environment: 'testnet' })
       const queryIndexer = sinon.stub(centrifuge as any, '_queryIndexer').returns(
         of({
           crosschainPayloads: {
             totalCount: 2,
+            pageInfo: { hasNextPage: true, hasPreviousPage: false, startCursor: 'a', endCursor: 'b' },
             items: [
-              {
-                id: '0xabc',
-                index: 0,
-                fromCentrifugeId: '1',
-                toCentrifugeId: '2',
-                poolId: poolId.raw.toString(),
-                tokenId: null,
-                status: 'InTransit',
-                gasLimit: '246355',
-                gasPrice: '1200014',
-                createdAt: '1773411360000',
-                deliveredAt: null,
-                completedAt: null,
-              },
-              {
+              basePayload(),
+              basePayload({
                 id: '0xdef',
                 index: 1,
-                fromCentrifugeId: '1',
                 toCentrifugeId: '3',
-                poolId: poolId.raw.toString(),
                 tokenId: '0xtoken',
                 status: 'Completed',
                 gasLimit: null,
                 gasPrice: null,
-                createdAt: '1773411360000',
                 deliveredAt: '1773411400000',
                 completedAt: '1773411500000',
-              },
+              }),
             ],
           },
         })
       )
       const pool = new Pool(centrifuge, poolId.raw)
 
-      const result = await pool.crosschainMessages({ status: ['InTransit', 'Underpaid'], fromCentrifugeId: 1, limit: 10 })
+      const result = await pool.crosschainMessages({
+        status: ['InTransit', 'Underpaid'],
+        fromCentrifugeId: 1,
+        after: 'cursor-x',
+        limit: 10,
+      })
       expect(result.totalCount).to.equal(2)
+      expect(result.pageInfo).to.deep.equal({
+        hasNextPage: true,
+        hasPreviousPage: false,
+        startCursor: 'a',
+        endCursor: 'b',
+      })
       expect(result.items).to.have.length(2)
-      expect(result.items[0]!.status).to.equal('InTransit')
       expect(result.items[0]!.fromCentrifugeId).to.equal(1)
       expect(result.items[0]!.toCentrifugeId).to.equal(2)
       expect(result.items[0]!.gasLimit).to.equal(246355n)
-      expect(result.items[0]!.gasPrice).to.equal(1200014n)
       expect(result.items[0]!.createdAt).to.be.instanceOf(Date)
       expect(result.items[0]!.deliveredAt).to.equal(undefined)
+      // Joins not requested -> undefined.
+      expect(result.items[0]!.pool).to.equal(undefined)
+      expect(result.items[0]!.innerMessages).to.equal(undefined)
       expect(result.items[1]!.gasLimit).to.equal(undefined)
       expect(result.items[1]!.deliveredAt).to.be.instanceOf(Date)
 
-      // Filter encoding: status_in for arrays, single status passed through, plus poolId always.
       const [, vars] = queryIndexer.firstCall.args as [string, Record<string, unknown>]
-      const filter = vars.filter as Record<string, unknown>
-      expect(filter).to.deep.include({
+      expect(vars.filter).to.deep.equal({
         poolId: poolId.raw.toString(),
         fromCentrifugeId: '1',
         status_in: ['InTransit', 'Underpaid'],
       })
-      expect(filter.toCentrifugeId).to.equal(undefined)
       expect(vars.limit).to.equal(10)
+      expect(vars.after).to.equal('cursor-x')
+    })
+
+    it('pool.crosschainMessages requests joined fields and maps them when `include` is set', async () => {
+      const centrifuge = new Centrifuge({ environment: 'testnet' })
+      const queryIndexer = sinon.stub(centrifuge as any, '_queryIndexer').returns(
+        of({
+          crosschainPayloads: {
+            totalCount: 1,
+            pageInfo: samplePageInfo,
+            items: [
+              basePayload({
+                pool: { id: poolId.raw.toString(), name: 'Foo Pool' },
+                token: { name: 'Foo Share', symbol: 'FOO' },
+                fromBlockchain: { id: '11155111', centrifugeId: '1', network: 'sepolia' },
+                toBlockchain: { id: '84532', centrifugeId: '2', network: 'base-sepolia' },
+                crosschainMessages: {
+                  items: [
+                    {
+                      id: '0xmsg',
+                      index: 0,
+                      poolId: poolId.raw.toString(),
+                      tokenId: null,
+                      payloadId: '0xabc',
+                      payloadIndex: 0,
+                      fromCentrifugeId: '1',
+                      toCentrifugeId: '2',
+                      messageType: 'NotifyPool',
+                      status: 'AwaitingBatchDelivery',
+                      rawData: '0xdeadbeef',
+                      data: { foo: 1 },
+                      failReason: null,
+                      createdAt: '1773411360000',
+                      executedAt: null,
+                      executedAtTxHash: null,
+                    },
+                  ],
+                },
+                adapterParticipations: {
+                  items: [
+                    {
+                      centrifugeId: '1',
+                      fromCentrifugeId: '1',
+                      toCentrifugeId: '2',
+                      type: 'PAYLOAD',
+                      side: 'SEND',
+                      gasPaid: '123',
+                      timestamp: '1773411360000',
+                      transactionHash: '0xtx',
+                      adapter: { address: '0xadapter', name: 'Axelar', centrifugeId: '1' },
+                    },
+                  ],
+                },
+              }),
+            ],
+          },
+        })
+      )
+      const pool = new Pool(centrifuge, poolId.raw)
+
+      const result = await pool.crosschainMessages({
+        include: { pool: true, token: true, blockchains: true, innerMessages: true, adapterParticipations: true },
+      })
+      const m = result.items[0]!
+      expect(m.pool).to.deep.equal({ id: poolId.raw.toString(), name: 'Foo Pool' })
+      expect(m.token).to.deep.equal({ name: 'Foo Share', symbol: 'FOO' })
+      expect(m.fromBlockchain).to.deep.equal({ id: '11155111', centrifugeId: 1, network: 'sepolia' })
+      expect(m.toBlockchain?.network).to.equal('base-sepolia')
+      expect(m.innerMessages).to.have.length(1)
+      expect(m.innerMessages![0]!.messageType).to.equal('NotifyPool')
+      expect(m.innerMessages![0]!.data).to.deep.equal({ foo: 1 })
+      expect(m.adapterParticipations).to.have.length(1)
+      expect(m.adapterParticipations![0]!.gasPaid).to.equal(123n)
+      expect(m.adapterParticipations![0]!.adapter?.name).to.equal('Axelar')
+
+      // The selection must include all join fragments.
+      const [query] = queryIndexer.firstCall.args as [string]
+      expect(query).to.match(/pool \{ id name \}/)
+      expect(query).to.match(/crosschainMessages \{/)
+      expect(query).to.match(/adapterParticipations\(orderBy/)
+    })
+
+    it('centrifuge.crosschainMessages encodes `preparedAtTxHash` filter and is not pool-scoped', async () => {
+      const centrifuge = new Centrifuge({ environment: 'testnet' })
+      const queryIndexer = sinon.stub(centrifuge as any, '_queryIndexer').returns(
+        of({ crosschainPayloads: { totalCount: 0, pageInfo: samplePageInfo, items: [] } })
+      )
+
+      await centrifuge.crosschainMessages({ preparedAtTxHash: '0xbatchtx' })
+
+      const [, vars] = queryIndexer.firstCall.args as [string, Record<string, unknown>]
+      const filter = vars.filter as Record<string, unknown>
+      expect(filter).to.deep.equal({ preparedAtTxHash: '0xbatchtx' })
+      expect(filter.poolId).to.equal(undefined)
+    })
+
+    it('centrifuge.crosschainMessage reads a single payload by (id, index) and defaults to all joins', async () => {
+      const centrifuge = new Centrifuge({ environment: 'testnet' })
+      const queryIndexer = sinon.stub(centrifuge as any, '_queryIndexer').returns(
+        of({
+          crosschainPayload: basePayload({
+            pool: { id: poolId.raw.toString(), name: 'Foo' },
+            token: null,
+            fromBlockchain: null,
+            toBlockchain: null,
+            crosschainMessages: { items: [] },
+            adapterParticipations: { items: [] },
+          }),
+        })
+      )
+
+      const message = await centrifuge.crosschainMessage('0xabc' as `0x${string}`, 0)
+      expect(message?.id).to.equal('0xabc')
+      expect(message?.pool?.name).to.equal('Foo')
+
+      const [query, vars] = queryIndexer.firstCall.args as [string, Record<string, unknown>]
+      expect(vars).to.deep.equal({ id: '0xabc', index: 0 })
+      // Default include = all joins, so the query selects them.
+      expect(query).to.match(/crosschainMessages \{/)
+      expect(query).to.match(/adapterParticipations\(orderBy/)
+    })
+
+    it('centrifuge.crosschainMessage returns undefined when the indexer has no record', async () => {
+      const centrifuge = new Centrifuge({ environment: 'testnet' })
+      sinon.stub(centrifuge as any, '_queryIndexer').returns(of({ crosschainPayload: null }))
+      const message = await centrifuge.crosschainMessage('0xmissing' as `0x${string}`, 0)
+      expect(message).to.equal(undefined)
     })
   })
 

--- a/src/Centrifuge.test.ts
+++ b/src/Centrifuge.test.ts
@@ -222,7 +222,7 @@ describe('Centrifuge', () => {
       expect(result.threshold).to.equal(1)
     })
 
-    it('pool.messages maps indexer payloads to typed CrosschainMessages and applies status filter', async () => {
+    it('pool.crosschainMessages maps indexer payloads to typed CrosschainMessages and applies status filter', async () => {
       const centrifuge = new Centrifuge({ environment: 'testnet' })
       const queryIndexer = sinon.stub(centrifuge as any, '_queryIndexer').returns(
         of({
@@ -263,7 +263,7 @@ describe('Centrifuge', () => {
       )
       const pool = new Pool(centrifuge, poolId.raw)
 
-      const result = await pool.messages({ status: ['InTransit', 'Underpaid'], fromCentrifugeId: 1, limit: 10 })
+      const result = await pool.crosschainMessages({ status: ['InTransit', 'Underpaid'], fromCentrifugeId: 1, limit: 10 })
       expect(result.totalCount).to.equal(2)
       expect(result.items).to.have.length(2)
       expect(result.items[0]!.status).to.equal('InTransit')

--- a/src/Centrifuge.ts
+++ b/src/Centrifuge.ts
@@ -37,6 +37,12 @@ import { verifyDeployments } from './config/verifyDeployments.js'
 import { PERMIT_TYPEHASH } from './constants.js'
 import { Investor } from './entities/Investor.js'
 import { Pool } from './entities/Pool.js'
+import {
+  queryCrosschainMessage,
+  queryCrosschainMessages,
+  type CrosschainMessageIncludes,
+  type CrosschainMessagesFilter,
+} from './entities/crosschainMessages.js'
 import type {
   Client,
   CurrencyDetails,
@@ -665,6 +671,28 @@ export class Centrifuge {
    * from the MultiAdapter contract on a hub chain. `poolId` is `0n` for the
    * global default slot. Used by `Pool.adapters()` and `globalAdapters()`.
    */
+  /**
+   * Query cross-chain messages across all pools. Pass `filter.poolId` to scope
+   * to one pool (or use `Pool.crosschainMessages` for the typed shortcut).
+   *
+   * Use `filter.include` to opt into nested data (pool, token, blockchains,
+   * inner messages, adapter participations). For long lists, pass
+   * `before`/`after` cursors from a previous page's `pageInfo`.
+   */
+  crosschainMessages(filter: CrosschainMessagesFilter = {}) {
+    return queryCrosschainMessages(this, filter)
+  }
+
+  /**
+   * Look up a single cross-chain message by its composite key
+   * `(payloadId, payloadIndex)`. Returns `undefined` when the indexer has no
+   * record. By default all available joins (pool, token, blockchains, inner
+   * messages, adapter participations) are included.
+   */
+  crosschainMessage(id: HexString, index: number, include?: CrosschainMessageIncludes) {
+    return queryCrosschainMessage(this, id, index, include)
+  }
+
   _readMultiAdapter(hubCentrifugeId: CentrifugeId, targetCentrifugeId: CentrifugeId, poolId: bigint) {
     return combineLatest([this._protocolAddresses(hubCentrifugeId), this.getClient(hubCentrifugeId)]).pipe(
       switchMap(([{ multiAdapter }, client]) =>

--- a/src/Centrifuge.ts
+++ b/src/Centrifuge.ts
@@ -644,6 +644,65 @@ export class Centrifuge {
   }
 
   /**
+   * Get the default (pool 0) adapter set and signature threshold configured on
+   * a hub's MultiAdapter for messages targeting another network. This is the
+   * fallback set used when a pool has no per-pool adapter configuration.
+   *
+   * @param hubCentrifugeId - The centrifuge ID of the hub chain where the
+   *   MultiAdapter contract lives.
+   * @param targetCentrifugeId - The centrifuge ID of the destination network.
+   */
+  globalAdapters(hubCentrifugeId: CentrifugeId, targetCentrifugeId: CentrifugeId) {
+    return this._query(['globalAdapters', hubCentrifugeId, targetCentrifugeId], () =>
+      this._readMultiAdapter(hubCentrifugeId, targetCentrifugeId, 0n)
+    )
+  }
+
+  /**
+   * @internal
+   *
+   * Read the adapter set and signature threshold for a `(target, poolId)` pair
+   * from the MultiAdapter contract on a hub chain. `poolId` is `0n` for the
+   * global default slot. Used by `Pool.adapters()` and `globalAdapters()`.
+   */
+  _readMultiAdapter(hubCentrifugeId: CentrifugeId, targetCentrifugeId: CentrifugeId, poolId: bigint) {
+    return combineLatest([this._protocolAddresses(hubCentrifugeId), this.getClient(hubCentrifugeId)]).pipe(
+      switchMap(([{ multiAdapter }, client]) =>
+        defer(async () => {
+          const [quorum, threshold] = await Promise.all([
+            client.readContract({
+              address: multiAdapter,
+              abi: ABI.MultiAdapter,
+              functionName: 'quorum',
+              args: [targetCentrifugeId, poolId],
+            }),
+            client.readContract({
+              address: multiAdapter,
+              abi: ABI.MultiAdapter,
+              functionName: 'threshold',
+              args: [targetCentrifugeId, poolId],
+            }),
+          ])
+          const adapters = await Promise.all(
+            Array.from({ length: Number(quorum) }, (_, index) =>
+              client.readContract({
+                address: multiAdapter,
+                abi: ABI.MultiAdapter,
+                functionName: 'adapters',
+                args: [targetCentrifugeId, poolId, BigInt(index)],
+              })
+            )
+          )
+          return {
+            adapters: adapters.map((addr) => addr.toLowerCase() as HexString),
+            threshold: Number(threshold),
+          }
+        })
+      )
+    )
+  }
+
+  /**
    * Register an asset
    * @param originCentrifugeId - The centrifuge ID where the asset exists
    * @param registerOnCentrifugeId - The centrifuge ID where the asset should be registered

--- a/src/abi/MultiAdapter.abi.ts
+++ b/src/abi/MultiAdapter.abi.ts
@@ -15,7 +15,7 @@ export default [
   // 'function rely(address user)',
   // 'function send(uint16 centrifugeId, bytes payload, uint256 gasLimit, address refund) payable returns (bytes32)',
   // 'function setAdapters(uint16 centrifugeId, uint64 poolId, address[] addresses, uint8 threshold_, uint8 recoveryIndex_)',
-  // 'function threshold(uint16 centrifugeId, uint64 poolId) view returns (uint8)',
+  'function threshold(uint16 centrifugeId, uint64 poolId) view returns (uint8)',
   // 'function votes(uint16 centrifugeId, bytes32 payloadHash) view returns (int16[8])',
   // 'function wards(address) view returns (uint256)',
   // 'event Deny(address indexed user)',

--- a/src/entities/Pool.ts
+++ b/src/entities/Pool.ts
@@ -15,6 +15,40 @@ import { Entity } from './Entity.js'
 import { PoolNetwork } from './PoolNetwork.js'
 import { PoolReports } from './Reports/PoolReports.js'
 import { ShareClass } from './ShareClass.js'
+
+/**
+ * Status of a cross-chain message (indexer-side `CrosschainPayload`).
+ *
+ * - `Underpaid` — gas paid was less than required; awaiting top-up.
+ * - `InTransit` — sent from the origin, not yet delivered on the destination.
+ * - `Delivered` — handled on the destination; may still be awaiting follow-up.
+ * - `PartiallyFailed` — at least one inner message failed.
+ * - `Completed` — fully processed end-to-end.
+ */
+export type CrosschainMessageStatus = 'Underpaid' | 'InTransit' | 'Delivered' | 'PartiallyFailed' | 'Completed'
+
+export type CrosschainMessagesFilter = {
+  fromCentrifugeId?: CentrifugeId
+  toCentrifugeId?: CentrifugeId
+  status?: CrosschainMessageStatus | CrosschainMessageStatus[]
+  limit?: number
+}
+
+export type CrosschainMessage = {
+  id: HexString
+  index: number
+  fromCentrifugeId: CentrifugeId
+  toCentrifugeId: CentrifugeId
+  poolId: string | null
+  tokenId: string | null
+  status: CrosschainMessageStatus
+  gasLimit: bigint | undefined
+  gasPrice: bigint | undefined
+  createdAt: Date
+  deliveredAt: Date | undefined
+  completedAt: Date | undefined
+}
+
 export class Pool extends Entity {
   id: PoolId
 
@@ -857,34 +891,103 @@ export class Pool extends Entity {
   }
 
   /**
-   * Get the configured adapters for a specific network.
-   * @param centrifugeId - The centrifuge ID of the network
+   * Get the configured adapter set and signature threshold for this pool on a
+   * specific network. Reads the MultiAdapter on the pool's hub chain.
+   *
+   * Use `centrifuge.globalAdapters(hub, target)` for the default (pool 0) set.
+   *
+   * @param centrifugeId - The centrifuge ID of the destination network
    */
   adapters(centrifugeId: CentrifugeId) {
     return this._query(['adapters', this.id.toString(), centrifugeId], () =>
-      combineLatest([this._root._protocolAddresses(this.centrifugeId), this._root.getClient(this.centrifugeId)]).pipe(
-        switchMap(([{ multiAdapter }, client]) =>
-          defer(async () => {
-            const quorum = await client.readContract({
-              address: multiAdapter,
-              abi: ABI.MultiAdapter,
-              functionName: 'quorum',
-              args: [centrifugeId, this.id.raw],
-            })
-            const adapters = await Promise.all(
-              Array.from({ length: quorum }, (_, index) =>
-                client.readContract({
-                  address: multiAdapter,
-                  abi: ABI.MultiAdapter,
-                  functionName: 'adapters',
-                  args: [centrifugeId, this.id.raw, BigInt(index)],
-                })
-              )
-            )
-            return adapters.map((addr) => addr.toLowerCase()) as HexString[]
-          })
-        )
-      )
+      this._root._readMultiAdapter(this.centrifugeId, centrifugeId, this.id.raw)
+    )
+  }
+
+  /**
+   * Query cross-chain messages (indexer-side: `CrosschainPayload`) for this
+   * pool. Without a filter, returns the most recent batch across all routes
+   * and statuses; `filter.status` is the common case (e.g. `'InTransit'` for
+   * pending in-flight messages).
+   *
+   * @param filter.fromCentrifugeId - Origin network filter.
+   * @param filter.toCentrifugeId - Destination network filter.
+   * @param filter.status - One status or an array of statuses to include.
+   * @param filter.limit - Page size. Default 100.
+   */
+  messages(filter: CrosschainMessagesFilter = {}) {
+    const { fromCentrifugeId, toCentrifugeId, status, limit = 100 } = filter
+    return this._query(
+      ['messages', this.id.toString(), fromCentrifugeId, toCentrifugeId, status?.toString(), limit],
+      () =>
+        this._root
+          ._queryIndexer<{
+            crosschainPayloads: {
+              totalCount: number
+              items: {
+                id: string
+                index: number
+                fromCentrifugeId: string
+                toCentrifugeId: string
+                poolId: string | null
+                tokenId: string | null
+                status: CrosschainMessageStatus
+                gasLimit: string | null
+                gasPrice: string | null
+                createdAt: string
+                deliveredAt: string | null
+                completedAt: string | null
+              }[]
+            }
+          }>(
+            `query ($filter: CrosschainPayloadFilter, $limit: Int!) {
+              crosschainPayloads(where: $filter, orderBy: "createdAt", orderDirection: "desc", limit: $limit) {
+                totalCount
+                items {
+                  id
+                  index
+                  fromCentrifugeId
+                  toCentrifugeId
+                  poolId
+                  tokenId
+                  status
+                  gasLimit
+                  gasPrice
+                  createdAt
+                  deliveredAt
+                  completedAt
+                }
+              }
+            }`,
+            {
+              filter: {
+                poolId: this.id.raw.toString(),
+                ...(fromCentrifugeId !== undefined ? { fromCentrifugeId: String(fromCentrifugeId) } : {}),
+                ...(toCentrifugeId !== undefined ? { toCentrifugeId: String(toCentrifugeId) } : {}),
+                ...(Array.isArray(status) ? { status_in: status } : status ? { status } : {}),
+              },
+              limit,
+            }
+          )
+          .pipe(
+            map(({ crosschainPayloads }) => ({
+              totalCount: crosschainPayloads.totalCount,
+              items: crosschainPayloads.items.map((item) => ({
+                id: item.id as HexString,
+                index: item.index,
+                fromCentrifugeId: Number(item.fromCentrifugeId) as CentrifugeId,
+                toCentrifugeId: Number(item.toCentrifugeId) as CentrifugeId,
+                poolId: item.poolId,
+                tokenId: item.tokenId,
+                status: item.status,
+                gasLimit: item.gasLimit ? BigInt(item.gasLimit) : undefined,
+                gasPrice: item.gasPrice ? BigInt(item.gasPrice) : undefined,
+                createdAt: new Date(Number(item.createdAt)),
+                deliveredAt: item.deliveredAt ? new Date(Number(item.deliveredAt)) : undefined,
+                completedAt: item.completedAt ? new Date(Number(item.completedAt)) : undefined,
+              })),
+            }))
+          )
     )
   }
 

--- a/src/entities/Pool.ts
+++ b/src/entities/Pool.ts
@@ -15,39 +15,7 @@ import { Entity } from './Entity.js'
 import { PoolNetwork } from './PoolNetwork.js'
 import { PoolReports } from './Reports/PoolReports.js'
 import { ShareClass } from './ShareClass.js'
-
-/**
- * Status of a cross-chain message (indexer-side `CrosschainPayload`).
- *
- * - `Underpaid` — gas paid was less than required; awaiting top-up.
- * - `InTransit` — sent from the origin, not yet delivered on the destination.
- * - `Delivered` — handled on the destination; may still be awaiting follow-up.
- * - `PartiallyFailed` — at least one inner message failed.
- * - `Completed` — fully processed end-to-end.
- */
-export type CrosschainMessageStatus = 'Underpaid' | 'InTransit' | 'Delivered' | 'PartiallyFailed' | 'Completed'
-
-export type CrosschainMessagesFilter = {
-  fromCentrifugeId?: CentrifugeId
-  toCentrifugeId?: CentrifugeId
-  status?: CrosschainMessageStatus | CrosschainMessageStatus[]
-  limit?: number
-}
-
-export type CrosschainMessage = {
-  id: HexString
-  index: number
-  fromCentrifugeId: CentrifugeId
-  toCentrifugeId: CentrifugeId
-  poolId: string | null
-  tokenId: string | null
-  status: CrosschainMessageStatus
-  gasLimit: bigint | undefined
-  gasPrice: bigint | undefined
-  createdAt: Date
-  deliveredAt: Date | undefined
-  completedAt: Date | undefined
-}
+import { queryCrosschainMessages, type CrosschainMessagesFilter } from './crosschainMessages.js'
 
 export class Pool extends Entity {
   id: PoolId
@@ -910,85 +878,12 @@ export class Pool extends Entity {
    * and statuses; `filter.status` is the common case (e.g. `'InTransit'` for
    * pending in-flight messages).
    *
-   * @param filter.fromCentrifugeId - Origin network filter.
-   * @param filter.toCentrifugeId - Destination network filter.
-   * @param filter.status - One status or an array of statuses to include.
-   * @param filter.limit - Page size. Default 100.
+   * Use `filter.include` to opt into nested data (pool, token, blockchains,
+   * inner messages, adapter participations). For paginating very long lists,
+   * pass `before`/`after` cursors from a previous page's `pageInfo`.
    */
-  crosschainMessages(filter: CrosschainMessagesFilter = {}) {
-    const { fromCentrifugeId, toCentrifugeId, status, limit = 100 } = filter
-    return this._query(
-      ['crosschainMessages', this.id.toString(), fromCentrifugeId, toCentrifugeId, status?.toString(), limit],
-      () =>
-        this._root
-          ._queryIndexer<{
-            crosschainPayloads: {
-              totalCount: number
-              items: {
-                id: string
-                index: number
-                fromCentrifugeId: string
-                toCentrifugeId: string
-                poolId: string | null
-                tokenId: string | null
-                status: CrosschainMessageStatus
-                gasLimit: string | null
-                gasPrice: string | null
-                createdAt: string
-                deliveredAt: string | null
-                completedAt: string | null
-              }[]
-            }
-          }>(
-            `query ($filter: CrosschainPayloadFilter, $limit: Int!) {
-              crosschainPayloads(where: $filter, orderBy: "createdAt", orderDirection: "desc", limit: $limit) {
-                totalCount
-                items {
-                  id
-                  index
-                  fromCentrifugeId
-                  toCentrifugeId
-                  poolId
-                  tokenId
-                  status
-                  gasLimit
-                  gasPrice
-                  createdAt
-                  deliveredAt
-                  completedAt
-                }
-              }
-            }`,
-            {
-              filter: {
-                poolId: this.id.raw.toString(),
-                ...(fromCentrifugeId !== undefined ? { fromCentrifugeId: String(fromCentrifugeId) } : {}),
-                ...(toCentrifugeId !== undefined ? { toCentrifugeId: String(toCentrifugeId) } : {}),
-                ...(Array.isArray(status) ? { status_in: status } : status ? { status } : {}),
-              },
-              limit,
-            }
-          )
-          .pipe(
-            map(({ crosschainPayloads }) => ({
-              totalCount: crosschainPayloads.totalCount,
-              items: crosschainPayloads.items.map((item) => ({
-                id: item.id as HexString,
-                index: item.index,
-                fromCentrifugeId: Number(item.fromCentrifugeId) as CentrifugeId,
-                toCentrifugeId: Number(item.toCentrifugeId) as CentrifugeId,
-                poolId: item.poolId,
-                tokenId: item.tokenId,
-                status: item.status,
-                gasLimit: item.gasLimit ? BigInt(item.gasLimit) : undefined,
-                gasPrice: item.gasPrice ? BigInt(item.gasPrice) : undefined,
-                createdAt: new Date(Number(item.createdAt)),
-                deliveredAt: item.deliveredAt ? new Date(Number(item.deliveredAt)) : undefined,
-                completedAt: item.completedAt ? new Date(Number(item.completedAt)) : undefined,
-              })),
-            }))
-          )
-    )
+  crosschainMessages(filter: Omit<CrosschainMessagesFilter, 'poolId'> = {}) {
+    return queryCrosschainMessages(this._root, { ...filter, poolId: this.id })
   }
 
   createAccounts(accounts: { accountId: bigint; isDebitNormal: boolean }[]) {

--- a/src/entities/Pool.ts
+++ b/src/entities/Pool.ts
@@ -915,10 +915,10 @@ export class Pool extends Entity {
    * @param filter.status - One status or an array of statuses to include.
    * @param filter.limit - Page size. Default 100.
    */
-  messages(filter: CrosschainMessagesFilter = {}) {
+  crosschainMessages(filter: CrosschainMessagesFilter = {}) {
     const { fromCentrifugeId, toCentrifugeId, status, limit = 100 } = filter
     return this._query(
-      ['messages', this.id.toString(), fromCentrifugeId, toCentrifugeId, status?.toString(), limit],
+      ['crosschainMessages', this.id.toString(), fromCentrifugeId, toCentrifugeId, status?.toString(), limit],
       () =>
         this._root
           ._queryIndexer<{

--- a/src/entities/crosschainMessages.ts
+++ b/src/entities/crosschainMessages.ts
@@ -1,0 +1,430 @@
+import { map } from 'rxjs'
+import type { Centrifuge } from '../Centrifuge.js'
+import type { HexString } from '../types/index.js'
+import type { Query } from '../types/query.js'
+import type { CentrifugeId, PoolId } from '../utils/types.js'
+
+/**
+ * Status of a cross-chain message envelope (indexer-side `CrosschainPayload`).
+ *
+ * - `Underpaid` — gas paid was less than required; awaiting top-up.
+ * - `InTransit` — sent from the origin, not yet delivered on the destination.
+ * - `Delivered` — handled on the destination; may still be awaiting follow-up.
+ * - `PartiallyFailed` — at least one inner message failed.
+ * - `Completed` — fully processed end-to-end.
+ */
+export type CrosschainMessageStatus = 'Underpaid' | 'InTransit' | 'Delivered' | 'PartiallyFailed' | 'Completed'
+
+/**
+ * Status of an inner cross-chain message (one of the messages bundled inside
+ * a `CrosschainMessage` envelope).
+ */
+export type CrosschainInnerMessageStatus = 'Unsent' | 'AwaitingBatchDelivery' | 'Failed' | 'Executed'
+
+export type AdapterParticipationType = 'PAYLOAD' | 'PROOF'
+export type AdapterParticipationSide = 'SEND' | 'HANDLE'
+
+export type CrosschainBlockchainRef = {
+  id: string
+  centrifugeId: CentrifugeId
+  network: string
+}
+
+export type CrosschainPoolRef = {
+  id: string
+  name: string | undefined
+}
+
+export type CrosschainTokenRef = {
+  name: string | undefined
+  symbol: string | undefined
+}
+
+export type CrosschainAdapterRef = {
+  address: HexString
+  name: string
+  centrifugeId: CentrifugeId
+}
+
+export type CrosschainInnerMessage = {
+  id: HexString
+  index: number
+  poolId: string | null
+  tokenId: string | null
+  payloadId: HexString
+  payloadIndex: number
+  fromCentrifugeId: CentrifugeId
+  toCentrifugeId: CentrifugeId
+  messageType: string
+  status: CrosschainInnerMessageStatus
+  rawData: HexString | undefined
+  data: unknown
+  failReason: string | undefined
+  createdAt: Date
+  executedAt: Date | undefined
+  executedAtTxHash: HexString | undefined
+}
+
+export type AdapterParticipation = {
+  centrifugeId: CentrifugeId
+  fromCentrifugeId: CentrifugeId
+  toCentrifugeId: CentrifugeId
+  type: AdapterParticipationType
+  side: AdapterParticipationSide
+  gasPaid: bigint | undefined
+  timestamp: Date
+  transactionHash: HexString
+  adapter?: CrosschainAdapterRef
+}
+
+/**
+ * Optional joined data on a cross-chain message. Each field is `undefined`
+ * unless the corresponding flag is set on the request's `include` option.
+ *
+ * Single-message reads (`centrifuge.crosschainMessage(id, index)`) request
+ * every join by default since the page renders one row.
+ */
+export type CrosschainMessageIncludes = {
+  pool?: boolean
+  token?: boolean
+  blockchains?: boolean
+  innerMessages?: boolean
+  adapterParticipations?: boolean
+}
+
+export type CrosschainMessage = {
+  id: HexString
+  index: number
+  poolId: string | null
+  tokenId: string | null
+  fromCentrifugeId: CentrifugeId
+  toCentrifugeId: CentrifugeId
+  status: CrosschainMessageStatus
+  rawData: HexString | undefined
+  gasLimit: bigint | undefined
+  gasPrice: bigint | undefined
+  createdAt: Date
+  deliveredAt: Date | undefined
+  completedAt: Date | undefined
+  preparedAtTxHash: HexString | undefined
+  deliveredAtTxHash: HexString | undefined
+  pool: CrosschainPoolRef | undefined
+  token: CrosschainTokenRef | undefined
+  fromBlockchain: CrosschainBlockchainRef | undefined
+  toBlockchain: CrosschainBlockchainRef | undefined
+  innerMessages: CrosschainInnerMessage[] | undefined
+  adapterParticipations: AdapterParticipation[] | undefined
+}
+
+export type CrosschainMessagesPageInfo = {
+  hasNextPage: boolean
+  hasPreviousPage: boolean
+  startCursor: string | null
+  endCursor: string | null
+}
+
+export type CrosschainMessagesPage = {
+  items: CrosschainMessage[]
+  totalCount: number
+  pageInfo: CrosschainMessagesPageInfo
+}
+
+export type CrosschainMessagesFilter = {
+  poolId?: PoolId | bigint
+  fromCentrifugeId?: CentrifugeId
+  toCentrifugeId?: CentrifugeId
+  status?: CrosschainMessageStatus | CrosschainMessageStatus[]
+  /** Match all payloads emitted by the same source transaction (batch). */
+  preparedAtTxHash?: HexString
+  limit?: number
+  before?: string
+  after?: string
+  include?: CrosschainMessageIncludes
+}
+
+const ALL_INCLUDES: Required<CrosschainMessageIncludes> = {
+  pool: true,
+  token: true,
+  blockchains: true,
+  innerMessages: true,
+  adapterParticipations: true,
+}
+
+const BLOCKCHAIN_FRAGMENT = `{ id centrifugeId network }`
+const POOL_FRAGMENT = `{ id name }`
+const TOKEN_FRAGMENT = `{ name symbol }`
+const INNER_MESSAGE_FRAGMENT = `{
+  items {
+    id
+    index
+    poolId
+    tokenId
+    payloadId
+    payloadIndex
+    fromCentrifugeId
+    toCentrifugeId
+    messageType
+    status
+    rawData
+    data
+    failReason
+    createdAt
+    executedAt
+    executedAtTxHash
+  }
+}`
+const ADAPTER_PARTICIPATIONS_FRAGMENT = `(orderBy: "timestamp", orderDirection: "asc") {
+  items {
+    centrifugeId
+    fromCentrifugeId
+    toCentrifugeId
+    type
+    side
+    gasPaid
+    timestamp
+    transactionHash
+    adapter { address name centrifugeId }
+  }
+}`
+
+const PAYLOAD_BASE_FIELDS = `
+  id
+  index
+  poolId
+  tokenId
+  fromCentrifugeId
+  toCentrifugeId
+  status
+  rawData
+  gasLimit
+  gasPrice
+  createdAt
+  deliveredAt
+  completedAt
+  preparedAtTxHash
+  deliveredAtTxHash
+`
+
+function payloadSelection(include: CrosschainMessageIncludes) {
+  const parts = [PAYLOAD_BASE_FIELDS]
+  if (include.pool) parts.push(`pool ${POOL_FRAGMENT}`)
+  if (include.token) parts.push(`token ${TOKEN_FRAGMENT}`)
+  if (include.blockchains) parts.push(`fromBlockchain ${BLOCKCHAIN_FRAGMENT}`, `toBlockchain ${BLOCKCHAIN_FRAGMENT}`)
+  if (include.innerMessages) parts.push(`crosschainMessages ${INNER_MESSAGE_FRAGMENT}`)
+  if (include.adapterParticipations) parts.push(`adapterParticipations${ADAPTER_PARTICIPATIONS_FRAGMENT}`)
+  return parts.join('\n      ')
+}
+
+type CrosschainPayloadRaw = {
+  id: string
+  index: number
+  poolId: string | null
+  tokenId: string | null
+  fromCentrifugeId: string
+  toCentrifugeId: string
+  status: CrosschainMessageStatus
+  rawData: string | null
+  gasLimit: string | null
+  gasPrice: string | null
+  createdAt: string
+  deliveredAt: string | null
+  completedAt: string | null
+  preparedAtTxHash: string | null
+  deliveredAtTxHash: string | null
+  pool?: { id: string; name: string | null } | null
+  token?: { name: string | null; symbol: string | null } | null
+  fromBlockchain?: { id: string; centrifugeId: string; network: string } | null
+  toBlockchain?: { id: string; centrifugeId: string; network: string } | null
+  crosschainMessages?: {
+    items: {
+      id: string
+      index: number
+      poolId: string | null
+      tokenId: string | null
+      payloadId: string
+      payloadIndex: number
+      fromCentrifugeId: string
+      toCentrifugeId: string
+      messageType: string
+      status: CrosschainInnerMessageStatus
+      rawData: string | null
+      data: unknown
+      failReason: string | null
+      createdAt: string
+      executedAt: string | null
+      executedAtTxHash: string | null
+    }[]
+  }
+  adapterParticipations?: {
+    items: {
+      centrifugeId: string
+      fromCentrifugeId: string
+      toCentrifugeId: string
+      type: AdapterParticipationType
+      side: AdapterParticipationSide
+      gasPaid: string | null
+      timestamp: string
+      transactionHash: string
+      adapter: { address: string; name: string; centrifugeId: string } | null
+    }[]
+  }
+}
+
+function toBlockchainRef(b: CrosschainPayloadRaw['fromBlockchain']): CrosschainBlockchainRef | undefined {
+  if (!b) return undefined
+  return { id: b.id, centrifugeId: Number(b.centrifugeId) as CentrifugeId, network: b.network }
+}
+
+function toMessage(raw: CrosschainPayloadRaw): CrosschainMessage {
+  return {
+    id: raw.id as HexString,
+    index: raw.index,
+    poolId: raw.poolId,
+    tokenId: raw.tokenId,
+    fromCentrifugeId: Number(raw.fromCentrifugeId) as CentrifugeId,
+    toCentrifugeId: Number(raw.toCentrifugeId) as CentrifugeId,
+    status: raw.status,
+    rawData: raw.rawData ? (raw.rawData as HexString) : undefined,
+    gasLimit: raw.gasLimit ? BigInt(raw.gasLimit) : undefined,
+    gasPrice: raw.gasPrice ? BigInt(raw.gasPrice) : undefined,
+    createdAt: new Date(Number(raw.createdAt)),
+    deliveredAt: raw.deliveredAt ? new Date(Number(raw.deliveredAt)) : undefined,
+    completedAt: raw.completedAt ? new Date(Number(raw.completedAt)) : undefined,
+    preparedAtTxHash: raw.preparedAtTxHash ? (raw.preparedAtTxHash as HexString) : undefined,
+    deliveredAtTxHash: raw.deliveredAtTxHash ? (raw.deliveredAtTxHash as HexString) : undefined,
+    pool: raw.pool ? { id: raw.pool.id, name: raw.pool.name ?? undefined } : undefined,
+    token: raw.token ? { name: raw.token.name ?? undefined, symbol: raw.token.symbol ?? undefined } : undefined,
+    fromBlockchain: toBlockchainRef(raw.fromBlockchain),
+    toBlockchain: toBlockchainRef(raw.toBlockchain),
+    innerMessages: raw.crosschainMessages?.items.map((m) => ({
+      id: m.id as HexString,
+      index: m.index,
+      poolId: m.poolId,
+      tokenId: m.tokenId,
+      payloadId: m.payloadId as HexString,
+      payloadIndex: m.payloadIndex,
+      fromCentrifugeId: Number(m.fromCentrifugeId) as CentrifugeId,
+      toCentrifugeId: Number(m.toCentrifugeId) as CentrifugeId,
+      messageType: m.messageType,
+      status: m.status,
+      rawData: m.rawData ? (m.rawData as HexString) : undefined,
+      data: m.data,
+      failReason: m.failReason ?? undefined,
+      createdAt: new Date(Number(m.createdAt)),
+      executedAt: m.executedAt ? new Date(Number(m.executedAt)) : undefined,
+      executedAtTxHash: m.executedAtTxHash ? (m.executedAtTxHash as HexString) : undefined,
+    })),
+    adapterParticipations: raw.adapterParticipations?.items.map((a) => ({
+      centrifugeId: Number(a.centrifugeId) as CentrifugeId,
+      fromCentrifugeId: Number(a.fromCentrifugeId) as CentrifugeId,
+      toCentrifugeId: Number(a.toCentrifugeId) as CentrifugeId,
+      type: a.type,
+      side: a.side,
+      gasPaid: a.gasPaid ? BigInt(a.gasPaid) : undefined,
+      timestamp: new Date(Number(a.timestamp)),
+      transactionHash: a.transactionHash as HexString,
+      adapter: a.adapter
+        ? {
+            address: a.adapter.address as HexString,
+            name: a.adapter.name,
+            centrifugeId: Number(a.adapter.centrifugeId) as CentrifugeId,
+          }
+        : undefined,
+    })),
+  }
+}
+
+function buildWhere(filter: CrosschainMessagesFilter) {
+  const { poolId, fromCentrifugeId, toCentrifugeId, status, preparedAtTxHash } = filter
+  return {
+    ...(poolId !== undefined ? { poolId: (typeof poolId === 'bigint' ? poolId : poolId.raw).toString() } : {}),
+    ...(fromCentrifugeId !== undefined ? { fromCentrifugeId: String(fromCentrifugeId) } : {}),
+    ...(toCentrifugeId !== undefined ? { toCentrifugeId: String(toCentrifugeId) } : {}),
+    ...(Array.isArray(status) ? { status_in: status } : status ? { status } : {}),
+    ...(preparedAtTxHash ? { preparedAtTxHash } : {}),
+  }
+}
+
+function filterCacheKey(filter: CrosschainMessagesFilter) {
+  const includeKey = Object.entries(filter.include ?? {})
+    .filter(([, v]) => v)
+    .map(([k]) => k)
+    .sort()
+    .join('|')
+  return [
+    'crosschainMessages',
+    filter.poolId !== undefined ? (typeof filter.poolId === 'bigint' ? filter.poolId : filter.poolId.raw).toString() : '',
+    filter.fromCentrifugeId,
+    filter.toCentrifugeId,
+    Array.isArray(filter.status) ? filter.status.join(',') : (filter.status ?? ''),
+    filter.preparedAtTxHash ?? '',
+    filter.limit ?? '',
+    filter.before ?? '',
+    filter.after ?? '',
+    includeKey,
+  ]
+}
+
+/** @internal */
+export function queryCrosschainMessages(
+  centrifuge: Centrifuge,
+  filter: CrosschainMessagesFilter
+): Query<CrosschainMessagesPage> {
+  const { limit = 100, before, after, include = {} } = filter
+  return centrifuge._query(filterCacheKey(filter), () =>
+    centrifuge
+      ._queryIndexer<{
+        crosschainPayloads: {
+          totalCount: number
+          pageInfo: CrosschainMessagesPageInfo
+          items: CrosschainPayloadRaw[]
+        }
+      }>(
+        `query ($filter: CrosschainPayloadFilter, $limit: Int!, $before: String, $after: String) {
+          crosschainPayloads(
+            where: $filter
+            orderBy: "createdAt"
+            orderDirection: "desc"
+            limit: $limit
+            before: $before
+            after: $after
+          ) {
+            totalCount
+            pageInfo { hasNextPage hasPreviousPage startCursor endCursor }
+            items {
+              ${payloadSelection(include)}
+            }
+          }
+        }`,
+        { filter: buildWhere(filter), limit, before, after }
+      )
+      .pipe(
+        map(({ crosschainPayloads }) => ({
+          items: crosschainPayloads.items.map(toMessage),
+          totalCount: crosschainPayloads.totalCount,
+          pageInfo: crosschainPayloads.pageInfo,
+        }))
+      )
+  ) as Query<CrosschainMessagesPage>
+}
+
+/** @internal */
+export function queryCrosschainMessage(
+  centrifuge: Centrifuge,
+  id: HexString,
+  index: number,
+  include: CrosschainMessageIncludes = ALL_INCLUDES
+): Query<CrosschainMessage | undefined> {
+  return centrifuge._query(['crosschainMessage', id, index, Object.keys(include).sort().join('|')], () =>
+    centrifuge
+      ._queryIndexer<{ crosschainPayload: CrosschainPayloadRaw | null }>(
+        `query ($id: String!, $index: Float!) {
+          crosschainPayload(id: $id, index: $index) {
+            ${payloadSelection(include)}
+          }
+        }`,
+        { id, index }
+      )
+      .pipe(map(({ crosschainPayload }) => (crosschainPayload ? toMessage(crosschainPayload) : undefined)))
+  ) as Query<CrosschainMessage | undefined>
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,23 @@ export * from './entities/Investor.js'
 export * from './entities/MerkleProofManager.js'
 export * from './entities/OnOffRampManager.js'
 export * from './entities/Pool.js'
+export type {
+  AdapterParticipation,
+  AdapterParticipationSide,
+  AdapterParticipationType,
+  CrosschainAdapterRef,
+  CrosschainBlockchainRef,
+  CrosschainInnerMessage,
+  CrosschainInnerMessageStatus,
+  CrosschainMessage,
+  CrosschainMessageIncludes,
+  CrosschainMessageStatus,
+  CrosschainMessagesFilter,
+  CrosschainMessagesPage,
+  CrosschainMessagesPageInfo,
+  CrosschainPoolRef,
+  CrosschainTokenRef,
+} from './entities/crosschainMessages.js'
 export * from './entities/PoolNetwork.js'
 export * from './entities/Reports/PoolReports.js'
 export * from './entities/Reports/PoolShareYieldsReport.js'


### PR DESCRIPTION
Surfaces the cross-chain adapter + payload data that apps-v3 and centrifugescan currently get by reaching into SDK internals (`_protocolAddresses`, `getClient`, `_queryIndexer`) or by hardcoding GraphQL strings.

## Adapters

**`pool.adapters(target)` — now returns `{ adapters, threshold }`** *(breaking)*
Reads `quorum`, `threshold`, and the per-index `adapters` from the MultiAdapter on the pool's hub chain in one go.

**`centrifuge.globalAdapters(hub, target)` — new** → `{ adapters, threshold }`
Same shape, but reads the MultiAdapter's default (`poolId 0`) slot — the fallback configuration when a pool has no per-pool overrides.

Un-comments `threshold(uint16,uint64)` on the exported `MultiAdapter` ABI.

## Cross-chain messages

**`pool.crosschainMessages(filter)` — new**
Pool-scoped wrapper around the indexer's `crosschainPayloads`. Returns `{ items, totalCount, pageInfo }`.

**`centrifuge.crosschainMessages(filter)` — new**
Same query, not pool-scoped. Pass `filter.poolId` to filter, or omit for the global list.

**`centrifuge.crosschainMessage(id, index)` — new**
Single payload lookup by composite key. All joins (pool/token/blockchains/inner messages/adapter participations) included by default.

Filters: `poolId`, `fromCentrifugeId`, `toCentrifugeId`, `status` (single or array), `preparedAtTxHash` (for batch lookups), `limit`, cursor `before`/`after`.

Joins are opt-in via `filter.include`:
```ts
type CrosschainMessageIncludes = {
  pool?: boolean
  token?: boolean
  blockchains?: boolean
  innerMessages?: boolean
  adapterParticipations?: boolean
}
```
Default = none for list queries (kept lean for high-traffic call sites like apps-v3's settings page), all for single reads.

The `CrosschainMessageStatus` enum is hand-written here (`Underpaid | InTransit | Delivered | PartiallyFailed | Completed`) rather than re-exported from the generated `types/indexer.ts` — that one is stale on `main`.

## Tests

7 unit tests in `Centrifuge.test.ts` cover: contract-read shapes for `globalAdapters` / `pool.adapters`, the payload → typed-message mapping, opt-in join requests, the `preparedAtTxHash` filter, single-payload reads, and missing-record handling.