### PR TITLE
fix: temporarily disable plume

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@centrifuge/sdk",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "",
   "homepage": "https://github.com/centrifuge/sdk/tree/main#readme",
   "author": "",

--- a/src/Centrifuge.ts
+++ b/src/Centrifuge.ts
@@ -59,6 +59,7 @@ import {
   type TransactionContext,
 } from './types/transaction.js'
 import { Balance } from './utils/BigInt.js'
+import { assertCrosschainMessagingEnabled } from './utils/crosschainHotfix.js'
 import { addEstimateBuffer, estimateBatchBridgeFee } from './utils/gas.js'
 import { generateShareClassSalt, randomUint } from './utils/index.js'
 import { createPinning, getUrlFromHash } from './utils/ipfs.js'
@@ -658,6 +659,9 @@ export class Centrifuge {
   ) {
     const self = this
     return this._transact(async function* (ctx) {
+      assertCrosschainMessagingEnabled(originCentrifugeId)
+      assertCrosschainMessagingEnabled(registerOnCentrifugeId)
+
       const [addresses, estimate] = await Promise.all([
         self._protocolAddresses(originCentrifugeId),
         self._estimate(originCentrifugeId, registerOnCentrifugeId, MessageType.RegisterAsset),
@@ -1230,8 +1234,10 @@ export class Centrifuge {
     toCentrifugeId: CentrifugeId,
     messageType: MessageTypeWithSubType | MessageTypeWithSubType[]
   ) {
-    return this._query(['estimate', fromCentrifugeId, toCentrifugeId, messageType], () =>
-      combineLatest([this._protocolAddresses(fromCentrifugeId), this.getClient(fromCentrifugeId)]).pipe(
+    return this._query(['estimate', fromCentrifugeId, toCentrifugeId, messageType], () => {
+      assertCrosschainMessagingEnabled(toCentrifugeId)
+
+      return combineLatest([this._protocolAddresses(fromCentrifugeId), this.getClient(fromCentrifugeId)]).pipe(
         switchMap(([{ multiAdapter, gasService }, publicClient]) => {
           const types = Array.isArray(messageType) ? messageType : [messageType]
           const gasMessagePayloads = types.map((type) => {
@@ -1247,7 +1253,7 @@ export class Centrifuge {
           })
         })
       )
-    )
+    })
   }
 
   /** @internal */

--- a/src/entities/MerkleProofManager.ts
+++ b/src/entities/MerkleProofManager.ts
@@ -9,6 +9,7 @@ import type { HexString } from '../types/index.js'
 import { MerkleProofPolicy, MerkleProofPolicyInput, MerkleProofWorkflow } from '../types/poolMetadata.js'
 import { MessageType } from '../types/transaction.js'
 import { Balance, BigIntWrapper, Price } from '../utils/BigInt.js'
+import { assertCrosschainMessagingEnabled } from '../utils/crosschainHotfix.js'
 import { addressToBytes32, encode } from '../utils/index.js'
 import { wrapTransaction } from '../utils/transaction.js'
 import { Entity } from './Entity.js'
@@ -164,6 +165,8 @@ export class MerkleProofManager extends Entity {
       ])
 
       const { SimpleMerkleTree: SimpleMerkleTreeConstructor } = importedMerkleTree.default || importedMerkleTree
+      assertCrosschainMessagingEnabled(id)
+
       const { metadata, shareClasses } = poolDetails
       const strategistAddress = strategist.toLowerCase()
       const existingEntry = metadata?.merkleProofManager?.[self.network.centrifugeId]?.[strategistAddress as any]
@@ -391,6 +394,8 @@ export class MerkleProofManager extends Entity {
       ])
 
       const { SimpleMerkleTree: SimpleMerkleTreeConstructor } = importedMerkleTree.default || importedMerkleTree
+      assertCrosschainMessagingEnabled(id)
+
       const { metadata, shareClasses } = poolDetails
 
       const policies = await buildPoliciesFromInputs(policyInputs, client)

--- a/src/entities/OnOffRampManager.ts
+++ b/src/entities/OnOffRampManager.ts
@@ -5,6 +5,7 @@ import { Centrifuge } from '../Centrifuge.js'
 import { HexString } from '../types/index.js'
 import { MessageType } from '../types/transaction.js'
 import { Balance } from '../utils/BigInt.js'
+import { assertCrosschainMessagingEnabled } from '../utils/crosschainHotfix.js'
 import { addressToBytes32, encode } from '../utils/index.js'
 import { doTransaction, wrapTransaction } from '../utils/transaction.js'
 import { AssetId } from '../utils/types.js'
@@ -171,6 +172,8 @@ export class OnOffRampManager extends Entity {
   setReceiver(assetId: AssetId, receiver: HexString, enabled: boolean = true) {
     const self = this
     return this._transact(async function* (ctx) {
+      assertCrosschainMessagingEnabled(self.network.centrifugeId)
+
       const { hub } = await self._root._protocolAddresses(self.network.pool.centrifugeId)
 
       yield* wrapTransaction(enabled ? 'Enable Receiver' : 'Disable Receiver', ctx, {
@@ -203,6 +206,8 @@ export class OnOffRampManager extends Entity {
   setRelayer(relayer: HexString, enabled: boolean = true) {
     const self = this
     return this._transact(async function* (ctx) {
+      assertCrosschainMessagingEnabled(self.network.centrifugeId)
+
       const { hub } = await self._root._protocolAddresses(self.network.pool.centrifugeId)
 
       yield* wrapTransaction(enabled ? 'Enable Relayer' : 'Disable Relayer', ctx, {
@@ -220,7 +225,9 @@ export class OnOffRampManager extends Entity {
             ctx.signingAddress,
           ],
         }),
-        messages: { [self.network.centrifugeId]: [{ type: MessageType.TrustedContractUpdate, poolId: self.network.pool.id }] },
+        messages: {
+          [self.network.centrifugeId]: [{ type: MessageType.TrustedContractUpdate, poolId: self.network.pool.id }],
+        },
       })
     }, self.network.pool.centrifugeId)
   }
@@ -228,6 +235,8 @@ export class OnOffRampManager extends Entity {
   setAsset(assetId: AssetId) {
     const self = this
     return this._transact(async function* (ctx) {
+      assertCrosschainMessagingEnabled(self.network.centrifugeId)
+
       const { hub } = await self._root._protocolAddresses(self.network.pool.centrifugeId)
 
       yield* wrapTransaction('Set Asset', ctx, {
@@ -245,7 +254,9 @@ export class OnOffRampManager extends Entity {
             ctx.signingAddress,
           ],
         }),
-        messages: { [self.network.centrifugeId]: [{ type: MessageType.TrustedContractUpdate, poolId: self.network.pool.id }] },
+        messages: {
+          [self.network.centrifugeId]: [{ type: MessageType.TrustedContractUpdate, poolId: self.network.pool.id }],
+        },
       })
     }, self.network.pool.centrifugeId)
   }

--- a/src/entities/Pool.ts
+++ b/src/entities/Pool.ts
@@ -7,6 +7,11 @@ import { PoolMetadataInput, ShareClassInput } from '../types/poolInput.js'
 import { PoolMetadata } from '../types/poolMetadata.js'
 import { MessageType, MessageTypeWithSubType } from '../types/transaction.js'
 import { NATIONAL_CURRENCY_METADATA } from '../utils/currencies.js'
+import {
+  addMessageForEnabledTarget,
+  filterCrosschainEnabledTargets,
+  isCrosschainMessagingDisabled,
+} from '../utils/crosschainHotfix.js'
 import { addressToBytes32, generateShareClassSalt } from '../utils/index.js'
 import { repeatOnEvents } from '../utils/rx.js'
 import { wrapTransaction } from '../utils/transaction.js'
@@ -641,10 +646,6 @@ export class Pool extends Entity {
 
       const batch: HexString[] = []
       const messages: Record<number, MessageTypeWithSubType[]> = {}
-      function addMessage(centId: number, message: MessageTypeWithSubType) {
-        if (!messages[centId]) messages[centId] = []
-        messages[centId].push(message)
-      }
 
       // Only add metadata update if we have a CID
       if (cid) {
@@ -683,6 +684,8 @@ export class Pool extends Entity {
       })
 
       for (const [centId, shareClasses] of shareClassesToBeUpdatedPerNetwork) {
+        if (isCrosschainMessagingDisabled(centId)) continue
+
         if (shareClasses.length > 0) {
           await Promise.all(
             shareClasses.map(async (sc: ShareClass) => {
@@ -694,7 +697,7 @@ export class Pool extends Entity {
                 })
               )
 
-              addMessage(centId, { type: MessageType.NotifyShareClass, poolId: self.id })
+              addMessageForEnabledTarget(messages, centId, { type: MessageType.NotifyShareClass, poolId: self.id })
             })
           )
         }
@@ -789,7 +792,8 @@ export class Pool extends Entity {
     const self = this
     return this._transact(async function* (ctx) {
       const [{ hub }] = await Promise.all([self._root._protocolAddresses(self.centrifugeId)])
-      const batch = updates.map(({ centrifugeId, address, canManage }) =>
+      const enabledUpdates = filterCrosschainEnabledTargets(updates)
+      const batch = enabledUpdates.map(({ centrifugeId, address, canManage }) =>
         encodeFunctionData({
           abi: ABI.Hub,
           functionName: 'updateBalanceSheetManager',
@@ -797,10 +801,16 @@ export class Pool extends Entity {
         })
       )
       const messages: Record<number, MessageTypeWithSubType[]> = {}
-      updates.forEach(({ centrifugeId }) => {
-        if (!messages[centrifugeId]) messages[centrifugeId] = []
-        messages[centrifugeId].push({ type: MessageType.UpdateBalanceSheetManager, poolId: self.id })
+      enabledUpdates.forEach(({ centrifugeId }) => {
+        addMessageForEnabledTarget(messages, centrifugeId, {
+          type: MessageType.UpdateBalanceSheetManager,
+          poolId: self.id,
+        })
       })
+
+      if (batch.length === 0) {
+        throw new Error('No enabled networks to update balance sheet managers')
+      }
 
       yield* wrapTransaction('Update balance sheet managers', ctx, {
         contract: hub,
@@ -826,7 +836,8 @@ export class Pool extends Entity {
     return this._transact(async function* (ctx) {
       const { hub } = await self._root._protocolAddresses(self.centrifugeId)
 
-      const batch = updates.map(({ centrifugeId, localAdapters, remoteAdapters, threshold, recoveryIndex }) =>
+      const enabledUpdates = filterCrosschainEnabledTargets(updates)
+      const batch = enabledUpdates.map(({ centrifugeId, localAdapters, remoteAdapters, threshold, recoveryIndex }) =>
         encodeFunctionData({
           abi: ABI.Hub,
           functionName: 'setAdapters',
@@ -843,10 +854,13 @@ export class Pool extends Entity {
       )
 
       const messages: Record<number, MessageTypeWithSubType[]> = {}
-      updates.forEach(({ centrifugeId }) => {
-        if (!messages[centrifugeId]) messages[centrifugeId] = []
-        messages[centrifugeId].push(MessageType.SetPoolAdapters)
+      enabledUpdates.forEach(({ centrifugeId }) => {
+        addMessageForEnabledTarget(messages, centrifugeId, MessageType.SetPoolAdapters)
       })
+
+      if (batch.length === 0) {
+        throw new Error('No enabled networks to set pool adapters')
+      }
 
       yield* wrapTransaction('Set pool adapters', ctx, {
         contract: hub,

--- a/src/entities/PoolNetwork.ts
+++ b/src/entities/PoolNetwork.ts
@@ -5,6 +5,7 @@ import type { Centrifuge } from '../Centrifuge.js'
 import { NULL_ADDRESS, SAFE_PROXY_BYTECODE } from '../constants.js'
 import { HexString } from '../types/index.js'
 import { MessageType, MessageTypeWithSubType, VaultUpdateKind } from '../types/transaction.js'
+import { assertCrosschainMessagingEnabled } from '../utils/crosschainHotfix.js'
 import { addressToBytes32, encode } from '../utils/index.js'
 import { makeThenable, repeatOnEvents } from '../utils/rx.js'
 import { doTransaction, parseEventLogs, wrapTransaction } from '../utils/transaction.js'
@@ -586,6 +587,8 @@ export class PoolNetwork extends Entity {
   ) {
     const self = this
     return this._transact(async function* (ctx) {
+      assertCrosschainMessagingEnabled(self.centrifugeId)
+
       const [
         {
           hub,
@@ -819,6 +822,8 @@ export class PoolNetwork extends Entity {
   unlinkVaults(vaults: { shareClassId: ShareClassId; assetId: AssetId; address: HexString }[]) {
     const self = this
     return this._transact(async function* (ctx) {
+      assertCrosschainMessagingEnabled(self.centrifugeId)
+
       if (vaults.length === 0) {
         throw new Error('No vaults to unlink')
       }
@@ -877,6 +882,8 @@ export class PoolNetwork extends Entity {
   linkVaults(vaults: { shareClassId: ShareClassId; assetId: AssetId; address: HexString }[]) {
     const self = this
     return this._transact(async function* (ctx) {
+      assertCrosschainMessagingEnabled(self.centrifugeId)
+
       if (vaults.length === 0) {
         throw new Error('No vaults to link')
       }

--- a/src/entities/ShareClass.ts
+++ b/src/entities/ShareClass.ts
@@ -20,6 +20,12 @@ import { MessageType, MessageTypeWithSubType } from '../types/transaction.js'
 import { convertToEvmAddress } from '../utils/addresses.js'
 import { AddressMap } from '../utils/AddressMap.js'
 import { Balance, Price } from '../utils/BigInt.js'
+import {
+  addMessageForEnabledTarget,
+  assertCrosschainMessagingEnabled,
+  filterCrosschainEnabledTargets,
+  isCrosschainMessagingDisabled,
+} from '../utils/crosschainHotfix.js'
 import { addressToBytes32, encode, randomUint } from '../utils/index.js'
 import { repeatOnEvents } from '../utils/rx.js'
 import { wrapTransaction } from '../utils/transaction.js'
@@ -651,10 +657,6 @@ export class ShareClass extends Entity {
       ])
       const batch: HexString[] = []
       const messages: Record<number, MessageTypeWithSubType[]> = {}
-      function addMessage(centId: number, message: MessageTypeWithSubType) {
-        if (!messages[centId]) messages[centId] = []
-        messages[centId].push(message)
-      }
 
       batch.push(
         encodeFunctionData({
@@ -671,8 +673,11 @@ export class ShareClass extends Entity {
 
       await Promise.all(
         activeNetworks.map(async (activeNetwork) => {
-          const networkDetails = await activeNetwork.details()
           const id = activeNetwork.centrifugeId
+
+          if (isCrosschainMessagingDisabled(id)) return
+
+          const networkDetails = await activeNetwork.details()
 
           const isShareClassInNetwork = networkDetails.activeShareClasses.find((shareClass) =>
             shareClass.id.equals(self.id)
@@ -686,7 +691,10 @@ export class ShareClass extends Entity {
                 args: [self.pool.id.raw, self.id.raw, id, ctx.signingAddress],
               })
             )
-            addMessage(id, { type: MessageType.NotifyPricePoolPerShare, poolId: self.pool.id })
+            addMessageForEnabledTarget(messages, id, {
+              type: MessageType.NotifyPricePoolPerShare,
+              poolId: self.pool.id,
+            })
           }
         })
       )
@@ -702,6 +710,8 @@ export class ShareClass extends Entity {
   setMaxAssetPriceAge(assetId: AssetId, maxPriceAge: number) {
     const self = this
     return this._transact(async function* (ctx) {
+      assertCrosschainMessagingEnabled(assetId.centrifugeId)
+
       const { hub } = await self._root._protocolAddresses(self.pool.centrifugeId)
       yield* wrapTransaction('Set max asset price age', ctx, {
         contract: hub,
@@ -720,6 +730,8 @@ export class ShareClass extends Entity {
   setMaxSharePriceAge(centrifugeId: CentrifugeId, maxPriceAge: number) {
     const self = this
     return this._transact(async function* (ctx) {
+      assertCrosschainMessagingEnabled(centrifugeId)
+
       const { hub } = await self._root._protocolAddresses(self.pool.centrifugeId)
       yield* wrapTransaction('Set max share price age', ctx, {
         contract: hub,
@@ -738,6 +750,8 @@ export class ShareClass extends Entity {
   notifyAssetPrice(assetId: AssetId) {
     const self = this
     return this._transact(async function* (ctx) {
+      assertCrosschainMessagingEnabled(assetId.centrifugeId)
+
       const { hub } = await self._root._protocolAddresses(self.pool.centrifugeId)
       yield* wrapTransaction('Notify asset price', ctx, {
         contract: hub,
@@ -756,6 +770,8 @@ export class ShareClass extends Entity {
   notifySharePrice(centrifugeId: CentrifugeId) {
     const self = this
     return this._transact(async function* (ctx) {
+      assertCrosschainMessagingEnabled(centrifugeId)
+
       const { hub } = await self._root._protocolAddresses(self.pool.centrifugeId)
       yield* wrapTransaction('Notify share price', ctx, {
         contract: hub,
@@ -802,9 +818,6 @@ export class ShareClass extends Entity {
         ),
       ])
       const pendingAmounts = pendingAmountsData.byVault
-      const assetsWithApprove = assets.filter((a) => 'approveAssetAmount' in a).length
-      const assetsWithIssue = assets.filter((a) => 'issuePricePerShare' in a).length
-      const gasLimitPerAsset = assetsWithIssue ? GAS_LIMIT / BigInt(assetsWithIssue) : 0n
       const estimatePerMessage = 700_000n
       const estimatePerMessageIfLocal = 360_000n
 
@@ -824,14 +837,17 @@ export class ShareClass extends Entity {
         throw new Error('Assets array contains multiple entries for the same asset ID')
       }
 
+      const crosschainEnabledAssets = assets.filter(
+        (asset) => !isCrosschainMessagingDisabled(asset.assetId.centrifugeId)
+      )
+      const assetsWithApprove = crosschainEnabledAssets.filter((a) => 'approveAssetAmount' in a).length
+      const assetsWithIssue = crosschainEnabledAssets.filter((a) => 'issuePricePerShare' in a).length
+      const gasLimitPerAsset = assetsWithIssue ? GAS_LIMIT / BigInt(assetsWithIssue) : 0n
+
       const batch: HexString[] = []
       const messages: Record<number, MessageTypeWithSubType[]> = {}
-      function addMessage(centId: number, message: MessageTypeWithSubType) {
-        if (!messages[centId]) messages[centId] = []
-        messages[centId].push(message)
-      }
 
-      for (const asset of assets) {
+      for (const asset of crosschainEnabledAssets) {
         const gasPerMessage =
           asset.assetId.centrifugeId === self.pool.centrifugeId ? estimatePerMessageIfLocal : estimatePerMessage
         let gasLeft = gasLimitPerAsset
@@ -864,7 +880,10 @@ export class ShareClass extends Entity {
               ],
             })
           )
-          addMessage(asset.assetId.centrifugeId, { type: MessageType.RequestCallback, poolId: self.pool.id })
+          addMessageForEnabledTarget(messages, asset.assetId.centrifugeId, {
+            type: MessageType.RequestCallback,
+            poolId: self.pool.id,
+          })
           gasLeft -= gasPerMessage
           nowDepositEpoch++
         }
@@ -900,7 +919,10 @@ export class ShareClass extends Entity {
                 ],
               })
             )
-            addMessage(asset.assetId.centrifugeId, { type: MessageType.RequestCallback, poolId: self.pool.id })
+            addMessageForEnabledTarget(messages, asset.assetId.centrifugeId, {
+              type: MessageType.RequestCallback,
+              poolId: self.pool.id,
+            })
             gasLeft -= gasPerMessage
           }
           // If we've issued shares, also notify a number of invest orders
@@ -923,7 +945,10 @@ export class ShareClass extends Entity {
                     ],
                   })
                 )
-                addMessage(asset.assetId.centrifugeId, { type: MessageType.RequestCallback, poolId: self.pool.id })
+                addMessageForEnabledTarget(messages, asset.assetId.centrifugeId, {
+                  type: MessageType.RequestCallback,
+                  poolId: self.pool.id,
+                })
               }
             })
           }
@@ -981,9 +1006,6 @@ export class ShareClass extends Entity {
       ])
       const pendingAmounts = pendingAmountsData.byVault
 
-      const assetsWithApprove = assets.filter((a) => 'approveShareAmount' in a).length
-      const assetsWithRevoke = assets.filter((a) => 'revokePricePerShare' in a).length
-      const gasLimitPerAsset = assetsWithRevoke ? GAS_LIMIT / BigInt(assetsWithRevoke) : 0n
       const estimatePerMessage = 700_000n
       const estimatePerMessageIfLocal = 360_000n
 
@@ -1003,14 +1025,17 @@ export class ShareClass extends Entity {
         throw new Error('Assets array contains multiple entries for the same asset ID')
       }
 
+      const crosschainEnabledAssets = assets.filter(
+        (asset) => !isCrosschainMessagingDisabled(asset.assetId.centrifugeId)
+      )
+      const assetsWithApprove = crosschainEnabledAssets.filter((a) => 'approveShareAmount' in a).length
+      const assetsWithRevoke = crosschainEnabledAssets.filter((a) => 'revokePricePerShare' in a).length
+      const gasLimitPerAsset = assetsWithRevoke ? GAS_LIMIT / BigInt(assetsWithRevoke) : 0n
+
       const batch: HexString[] = []
       const messages: Record<number, MessageTypeWithSubType[]> = {}
-      function addMessage(centId: number, message: MessageTypeWithSubType) {
-        if (!messages[centId]) messages[centId] = []
-        messages[centId].push(message)
-      }
 
-      for (const asset of assets) {
+      for (const asset of crosschainEnabledAssets) {
         const gasPerMessage =
           asset.assetId.centrifugeId === self.pool.centrifugeId ? estimatePerMessageIfLocal : estimatePerMessage
         let gasLeft = gasLimitPerAsset
@@ -1075,7 +1100,10 @@ export class ShareClass extends Entity {
                 ],
               })
             )
-            addMessage(asset.assetId.centrifugeId, { type: MessageType.RequestCallback, poolId: self.pool.id })
+            addMessageForEnabledTarget(messages, asset.assetId.centrifugeId, {
+              type: MessageType.RequestCallback,
+              poolId: self.pool.id,
+            })
             gasLeft -= gasPerMessage
           }
 
@@ -1099,7 +1127,10 @@ export class ShareClass extends Entity {
                     ],
                   })
                 )
-                addMessage(asset.assetId.centrifugeId, { type: MessageType.RequestCallback, poolId: self.pool.id })
+                addMessageForEnabledTarget(messages, asset.assetId.centrifugeId, {
+                  type: MessageType.RequestCallback,
+                  poolId: self.pool.id,
+                })
               }
             })
           }
@@ -1131,6 +1162,8 @@ export class ShareClass extends Entity {
   claimDeposit(assetId: AssetId, investor: HexString) {
     const self = this
     return this._transact(async function* (ctx) {
+      assertCrosschainMessagingEnabled(assetId.centrifugeId)
+
       const [{ batchRequestManager }, investorOrder] = await Promise.all([
         self._root._protocolAddresses(self.pool.centrifugeId),
         self._investorOrder(assetId, investor),
@@ -1161,6 +1194,8 @@ export class ShareClass extends Entity {
   claimRedeem(assetId: AssetId, investor: HexString) {
     const self = this
     return this._transact(async function* (ctx) {
+      assertCrosschainMessagingEnabled(assetId.centrifugeId)
+
       const [{ batchRequestManager }, investorOrder] = await Promise.all([
         self._root._protocolAddresses(self.pool.centrifugeId),
         self._investorOrder(assetId, investor),
@@ -1209,12 +1244,8 @@ export class ShareClass extends Entity {
 
       const batch: HexString[] = []
       const messages: Record<number, MessageTypeWithSubType[]> = {}
-      function addMessage(centId: number, message: MessageTypeWithSubType) {
-        if (!messages[centId]) messages[centId] = []
-        messages[centId].push(message)
-      }
 
-      members.forEach((member) => {
+      filterCrosschainEnabledTargets(members).forEach((member) => {
         batch.push(
           encodeFunctionData({
             abi: ABI.Hub,
@@ -1232,7 +1263,10 @@ export class ShareClass extends Entity {
             ],
           })
         )
-        addMessage(member.centrifugeId, { type: MessageType.UpdateRestriction, poolId: self.pool.id })
+        addMessageForEnabledTarget(messages, member.centrifugeId, {
+          type: MessageType.UpdateRestriction,
+          poolId: self.pool.id,
+        })
       })
 
       if (batch.length === 0) {
@@ -1533,6 +1567,8 @@ export class ShareClass extends Entity {
     const self = this
 
     return this._transact(async function* (ctx) {
+      assertCrosschainMessagingEnabled(centrifugeId)
+
       const { hub } = await self._root._protocolAddresses(self.pool.centrifugeId)
       const payload = encodePacked(
         ['uint8', 'bytes32'],
@@ -1560,6 +1596,8 @@ export class ShareClass extends Entity {
     const self = this
 
     return this._transact(async function* (ctx) {
+      assertCrosschainMessagingEnabled(centrifugeId)
+
       const { hub } = await self._root._protocolAddresses(self.pool.centrifugeId)
       const payload = encodePacked(
         ['uint8', 'bytes32'],
@@ -2313,6 +2351,8 @@ export class ShareClass extends Entity {
   updateValuation(centrifugeId: CentrifugeId, valuation: HexString) {
     const self = this
     return this._transact(async function* (ctx) {
+      assertCrosschainMessagingEnabled(centrifugeId)
+
       const [{ hub }, spokeAddresses] = await Promise.all([
         self._root._protocolAddresses(self.pool.centrifugeId),
         self._root._protocolAddresses(centrifugeId),
@@ -2346,6 +2386,8 @@ export class ShareClass extends Entity {
   updateHook(centrifugeId: CentrifugeId, hook: HexString) {
     const self = this
     return this._transact(async function* (ctx) {
+      assertCrosschainMessagingEnabled(centrifugeId)
+
       const { hub } = await self._root._protocolAddresses(self.pool.centrifugeId)
 
       yield* wrapTransaction('Update hook', ctx, {
@@ -2373,6 +2415,8 @@ export class ShareClass extends Entity {
 
     const self = this
     return this._transact(async function* (ctx) {
+      assertCrosschainMessagingEnabled(centrifugeId)
+
       const [{ hub }, spokeAddresses] = await Promise.all([
         self._root._protocolAddresses(self.pool.centrifugeId),
         self._root._protocolAddresses(centrifugeId),
@@ -2557,6 +2601,9 @@ export class ShareClass extends Entity {
   ) {
     const self = this
     return this._transact(async function* (ctx) {
+      assertCrosschainMessagingEnabled(sourceCentrifugeId)
+      assertCrosschainMessagingEnabled(destinationCentrifugeId)
+
       const { spoke } = await self._root._protocolAddresses(sourceCentrifugeId)
 
       yield* wrapTransaction('Cross chain transfer shares', ctx, {
@@ -3469,6 +3516,8 @@ export class ShareClass extends Entity {
   _updateContract(centrifugeId: CentrifugeId, target: HexString, payload: HexString) {
     const self = this
     return this._transact(async function* (ctx) {
+      assertCrosschainMessagingEnabled(centrifugeId)
+
       const { hub } = await self._root._protocolAddresses(self.pool.centrifugeId)
       yield* wrapTransaction('Update contract', ctx, {
         contract: hub,

--- a/src/entities/Vault.ts
+++ b/src/entities/Vault.ts
@@ -5,6 +5,7 @@ import type { Centrifuge } from '../Centrifuge.js'
 import type { HexString } from '../types/index.js'
 import { MessageType } from '../types/transaction.js'
 import { Balance } from '../utils/BigInt.js'
+import { assertCrosschainMessagingEnabled } from '../utils/crosschainHotfix.js'
 import { addressToBytes32, encode } from '../utils/index.js'
 import { Permit, signPermit } from '../utils/permit.js'
 import { repeatOnEvents } from '../utils/rx.js'
@@ -348,8 +349,13 @@ export class Vault extends Entity {
   asyncDeposit(amount: Balance) {
     const self = this
     return this._transact(async function* (ctx) {
+      assertCrosschainMessagingEnabled(self.centrifugeId)
+
       const [estimate, investment, { vaultRouter }, isSyncDeposit, signingAddressCode] = await Promise.all([
-        self._root._estimate(self.centrifugeId, self.pool.id.centrifugeId, { type: MessageType.Request, poolId: self.pool.id }),
+        self._root._estimate(self.centrifugeId, self.pool.id.centrifugeId, {
+          type: MessageType.Request,
+          poolId: self.pool.id,
+        }),
         self.investment(ctx.signingAddress),
         self._root._protocolAddresses(self.centrifugeId),
         self._isSyncDeposit(),
@@ -429,8 +435,13 @@ export class Vault extends Entity {
   cancelDepositRequest() {
     const self = this
     return this._transact(async function* (ctx) {
+      assertCrosschainMessagingEnabled(self.centrifugeId)
+
       const [estimate, investment, { vaultRouter }] = await Promise.all([
-        self._root._estimate(self.centrifugeId, self.pool.id.centrifugeId, { type: MessageType.Request, poolId: self.pool.id }),
+        self._root._estimate(self.centrifugeId, self.pool.id.centrifugeId, {
+          type: MessageType.Request,
+          poolId: self.pool.id,
+        }),
         self.investment(ctx.signingAddress),
         self._root._protocolAddresses(self.centrifugeId),
       ])
@@ -456,8 +467,13 @@ export class Vault extends Entity {
   asyncRedeem(sharesAmount: Balance) {
     const self = this
     return this._transact(async function* (ctx) {
+      assertCrosschainMessagingEnabled(self.centrifugeId)
+
       const [estimate, investment, { vaultRouter }, isOperator] = await Promise.all([
-        self._root._estimate(self.centrifugeId, self.pool.id.centrifugeId, { type: MessageType.Request, poolId: self.pool.id }),
+        self._root._estimate(self.centrifugeId, self.pool.id.centrifugeId, {
+          type: MessageType.Request,
+          poolId: self.pool.id,
+        }),
         self.investment(ctx.signingAddress),
         self._root._protocolAddresses(self.centrifugeId),
         self._isOperator(ctx.signingAddress),
@@ -509,8 +525,13 @@ export class Vault extends Entity {
   cancelRedeemRequest() {
     const self = this
     return this._transact(async function* (ctx) {
+      assertCrosschainMessagingEnabled(self.centrifugeId)
+
       const [estimate, investment, { vaultRouter }] = await Promise.all([
-        self._root._estimate(self.centrifugeId, self.pool.id.centrifugeId, { type: MessageType.Request, poolId: self.pool.id }),
+        self._root._estimate(self.centrifugeId, self.pool.id.centrifugeId, {
+          type: MessageType.Request,
+          poolId: self.pool.id,
+        }),
         self.investment(ctx.signingAddress),
         self._root._protocolAddresses(self.centrifugeId),
       ])

--- a/src/utils/crosschainHotfix.test.ts
+++ b/src/utils/crosschainHotfix.test.ts
@@ -1,0 +1,39 @@
+import { expect } from 'chai'
+import { MessageType, type MessageTypeWithSubType } from '../types/transaction.js'
+import { PoolId } from './types.js'
+import {
+  addMessageForEnabledTarget,
+  assertCrosschainMessagingEnabled,
+  assertMessagesDoNotTargetDisabledChains,
+  PLUME_CENTRIFUGE_ID,
+} from './crosschainHotfix.js'
+
+describe('crosschainHotfix', () => {
+  const poolId = PoolId.from(1, 1)
+
+  it('skips messages targeting Plume', () => {
+    const messages: Record<number, MessageTypeWithSubType[]> = {
+      1: [{ type: MessageType.NotifyPricePoolPerShare, poolId }],
+    }
+
+    const added = addMessageForEnabledTarget(messages, PLUME_CENTRIFUGE_ID, {
+      type: MessageType.NotifyPricePoolPerShare,
+      poolId,
+    })
+
+    expect(added).to.equal(false)
+    expect(messages).to.have.keys(['1'])
+  })
+
+  it('throws before estimating or submitting Plume messages', () => {
+    expect(() => assertCrosschainMessagingEnabled(PLUME_CENTRIFUGE_ID)).to.throw(
+      `Cross-chain messaging for centrifugeId ${PLUME_CENTRIFUGE_ID} is temporarily disabled`
+    )
+
+    expect(() =>
+      assertMessagesDoNotTargetDisabledChains({
+        [PLUME_CENTRIFUGE_ID]: [{ type: MessageType.NotifyPricePoolPerShare, poolId }],
+      })
+    ).to.throw(`Cross-chain messaging for centrifugeId ${PLUME_CENTRIFUGE_ID} is temporarily disabled`)
+  })
+})

--- a/src/utils/crosschainHotfix.ts
+++ b/src/utils/crosschainHotfix.ts
@@ -1,0 +1,46 @@
+import type { MessageTypeWithSubType } from '../types/transaction.js'
+import type { CentrifugeId } from './types.js'
+
+export const PLUME_CENTRIFUGE_ID = 4
+
+// Temporary production hotfix: Plume cross-chain messaging is disabled until the
+// protocol adapter wiring is fixed. Remove this allowlist once Ops confirms Plume.
+export const TEMPORARILY_DISABLED_CROSSCHAIN_CENTRIFUGE_IDS = [PLUME_CENTRIFUGE_ID] as const
+
+const disabledCentrifugeIds = new Set<number>(TEMPORARILY_DISABLED_CROSSCHAIN_CENTRIFUGE_IDS)
+
+export function isCrosschainMessagingDisabled(centrifugeId: CentrifugeId) {
+  return disabledCentrifugeIds.has(centrifugeId)
+}
+
+export function getCrosschainMessagingDisabledError(centrifugeId: CentrifugeId) {
+  return new Error(`Cross-chain messaging for centrifugeId ${centrifugeId} is temporarily disabled`)
+}
+
+export function assertCrosschainMessagingEnabled(centrifugeId: CentrifugeId) {
+  if (isCrosschainMessagingDisabled(centrifugeId)) {
+    throw getCrosschainMessagingDisabledError(centrifugeId)
+  }
+}
+
+export function addMessageForEnabledTarget(
+  messages: Record<number, MessageTypeWithSubType[]>,
+  centrifugeId: CentrifugeId,
+  message: MessageTypeWithSubType
+) {
+  if (isCrosschainMessagingDisabled(centrifugeId)) return false
+
+  if (!messages[centrifugeId]) messages[centrifugeId] = []
+  messages[centrifugeId].push(message)
+  return true
+}
+
+export function filterCrosschainEnabledTargets<T extends { centrifugeId: CentrifugeId }>(items: T[]) {
+  return items.filter((item) => !isCrosschainMessagingDisabled(item.centrifugeId))
+}
+
+export function assertMessagesDoNotTargetDisabledChains(messages: Record<number, MessageTypeWithSubType[]>) {
+  Object.keys(messages).forEach((centrifugeId) => {
+    assertCrosschainMessagingEnabled(Number(centrifugeId))
+  })
+}

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -21,6 +21,7 @@ import type {
   Signer,
   TransactionContext,
 } from '../types/transaction.js'
+import { assertMessagesDoNotTargetDisabledChains } from './crosschainHotfix.js'
 import { CentrifugeId } from './types.js'
 
 class TransactionError extends Error {
@@ -91,6 +92,10 @@ export async function* wrapTransaction(
       messages,
     }
   } else {
+    if (messages) {
+      assertMessagesDoNotTargetDisabledChains(messages)
+    }
+
     const messagesEstimates = messages
       ? await Promise.all(
           Object.entries(messages).map(async ([centId, messageTypes]) =>


### PR DESCRIPTION
  - Added a temporary Plume disable flag in sdk/src/utils/crosschainHotfix.ts:4.
  - SDK now blocks fee estimation/submission for Plume-targeted cross-chain messages in sdk/src/Centrifuge.ts:1237 and sdk/src/utils/transaction.ts:95.
  - NAV/share-price updates now skip Plume when building notifySharePrice messages, while still updating the hub price for the pool in sdk/src/entities/ShareClass.ts:651.
  - Other SDK cross-chain management actions now either filter Plume from batches or fail early for Plume-only actions.