### PR TITLE
feat: authorizeOnchainPM — register BSM + grant accounting-token minter

### DIFF
--- a/src/Centrifuge.ts
+++ b/src/Centrifuge.ts
@@ -94,10 +94,10 @@ const TESTNET_ONCHAIN_PM_FACTORY_BY_CENTRIFUGE_ID: Record<number, HexString> = {
 
 // Temporary testnet shim until the indexer exposes Deployment.accountingToken.
 const TESTNET_ACCOUNTING_TOKEN_BY_CENTRIFUGE_ID: Record<number, HexString> = {
-  1: '0x4D0c60ec2127Ded422F61C0725b4775c0c361AEd',
-  2: '0x4D0c60ec2127Ded422F61C0725b4775c0c361AEd',
-  3: '0x4D0c60ec2127Ded422F61C0725b4775c0c361AEd',
-  9: '0x4D0c60ec2127Ded422F61C0725b4775c0c361AEd',
+  1: '0x5ba3f068cefa1e84adafcb7191bf4c02c3b724f8',
+  2: '0x5ba3f068cefa1e84adafcb7191bf4c02c3b724f8',
+  3: '0x5ba3f068cefa1e84adafcb7191bf4c02c3b724f8',
+  9: '0x5ba3f068cefa1e84adafcb7191bf4c02c3b724f8',
 }
 
 const envConfig = {

--- a/src/Centrifuge.ts
+++ b/src/Centrifuge.ts
@@ -92,6 +92,14 @@ const TESTNET_ONCHAIN_PM_FACTORY_BY_CENTRIFUGE_ID: Record<number, HexString> = {
   9: '0xF3c808e6D7C25B19c97a9597CaAcFB8Ba780a580',
 }
 
+// Temporary testnet shim until the indexer exposes Deployment.accountingToken.
+const TESTNET_ACCOUNTING_TOKEN_BY_CENTRIFUGE_ID: Record<number, HexString> = {
+  1: '0x4D0c60ec2127Ded422F61C0725b4775c0c361AEd',
+  2: '0x4D0c60ec2127Ded422F61C0725b4775c0c361AEd',
+  3: '0x4D0c60ec2127Ded422F61C0725b4775c0c361AEd',
+  9: '0x4D0c60ec2127Ded422F61C0725b4775c0c361AEd',
+}
+
 const envConfig = {
   mainnet: {
     indexerUrl: 'https://api.centrifuge.io',
@@ -1443,7 +1451,12 @@ export class Centrifuge {
               items: data.deployments.items.map((deployment) => {
                 const centrifugeId = Number(deployment.centrifugeId)
                 const onchainPMFactory = TESTNET_ONCHAIN_PM_FACTORY_BY_CENTRIFUGE_ID[centrifugeId]
-                return onchainPMFactory ? { ...deployment, onchainPMFactory } : deployment
+                const accountingToken = TESTNET_ACCOUNTING_TOKEN_BY_CENTRIFUGE_ID[centrifugeId]
+                return {
+                  ...deployment,
+                  ...(onchainPMFactory ? { onchainPMFactory } : {}),
+                  ...(accountingToken ? { accountingToken } : {}),
+                }
               }),
             },
           }

--- a/src/entities/OnchainPM.ts
+++ b/src/entities/OnchainPM.ts
@@ -1,6 +1,6 @@
 import type { SimpleMerkleTree } from '@openzeppelin/merkle-tree'
-import { from, switchMap } from 'rxjs'
-import { encodeFunctionData, toHex } from 'viem'
+import { combineLatest, from, map, switchMap } from 'rxjs'
+import { encodeFunctionData, parseAbi, toHex } from 'viem'
 import { ABI } from '../abi/index.js'
 import type { Centrifuge } from '../Centrifuge.js'
 import type { HexString } from '../types/index.js'
@@ -38,6 +38,34 @@ export class OnchainPM extends Entity {
               args: [strategist],
             })
           )
+        )
+      )
+    )
+  }
+
+  /**
+   * Whether this OnchainPM is fully authorized to run workflows for the pool —
+   * i.e. it is both a balance sheet manager and a minter on the pool's
+   * accounting token. `authorizeOnchainPM` grants both; surface this so the UI
+   * can detect a partial/stale state and re-authorize.
+   */
+  isAuthorized() {
+    const self = this
+    return this._query(['isAuthorized'], () =>
+      combineLatest([
+        from(this._root._protocolAddresses(this.network.centrifugeId)),
+        from(this._root.getClient(this.network.centrifugeId)),
+        this.network.pool.isBalanceSheetManager(this.network.centrifugeId, this.address),
+      ]).pipe(
+        switchMap(([{ accountingToken }, client, isBalanceSheetManager]) =>
+          from(
+            client.readContract({
+              address: accountingToken,
+              abi: parseAbi(['function minters(uint64, address) view returns (bool)']),
+              functionName: 'minters',
+              args: [self.network.pool.id.raw, self.address],
+            })
+          ).pipe(map((isMinter) => Boolean(isBalanceSheetManager) && Boolean(isMinter)))
         )
       )
     )

--- a/src/entities/PoolNetwork.test.ts
+++ b/src/entities/PoolNetwork.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai'
 import { lastValueFrom, Observable, of } from 'rxjs'
 import sinon from 'sinon'
-import { encodeAbiParameters, encodeEventTopics, parseAbi } from 'viem'
+import { decodeFunctionData, encodeAbiParameters, encodeEventTopics, parseAbi } from 'viem'
 import type { TransactionReceipt } from 'viem'
 import { ABI } from '../abi/index.js'
 import { Centrifuge } from '../Centrifuge.js'
@@ -646,33 +646,51 @@ describe('PoolNetwork.deployOnchainPM', () => {
 })
 
 describe('PoolNetwork.registerOnchainPMAsBSManager', () => {
+  const hub = '0xcccccccccccccccccccccccccccccccccccccccc'
+  const accountingToken = '0xdddddddddddddddddddddddddddddddddddddddd'
+  const managerAddress = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' as const
+
   afterEach(() => {
     sinon.restore()
   })
 
-  it('registers the OnchainPM as a balance sheet manager for the current network', async () => {
+  it('batches the BSM registration and the accounting-token minter grant into one hub transaction', async () => {
     const root = {
-      _transact: sinon.stub(),
+      _protocolAddresses: sinon.stub().resolves({ hub, accountingToken }),
+      _transact: (callback: (ctx: any) => AsyncGenerator<unknown> | Observable<unknown>, cId: number) => {
+        const tx = new Observable<unknown>((subscriber) => {
+          ;(async () => {
+            try {
+              // isBatching short-circuits wrapTransaction to yield the raw batch payload.
+              const result = callback({ isBatching: true, signingAddress, centrifugeId: cId, root })
+              if (Symbol.asyncIterator in result) {
+                for await (const item of result) subscriber.next(item)
+              } else {
+                result.subscribe(subscriber)
+                return
+              }
+              subscriber.complete()
+            } catch (error) {
+              subscriber.error(error)
+            }
+          })()
+        })
+        return Object.assign(tx, { centrifugeId: cId })
+      },
     }
+
     const pool = new Pool(root as any, poolId.raw)
-    const updateBalanceSheetManagers = sinon
-      .stub(pool, 'updateBalanceSheetManagers')
-      .returns(of({ type: 'TransactionConfirmed' } as any) as any)
-
+    sinon.stub(pool, 'shareClasses').returns(of([{ id: { raw: scId.raw } }]) as any)
     const pn = new PoolNetwork(root as any, pool, centId)
-    const managerAddress = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' as const
 
-    await lastValueFrom(pn.registerOnchainPMAsBSManager(managerAddress) as unknown as Observable<any>)
+    const batch = (await lastValueFrom(
+      pn.registerOnchainPMAsBSManager(managerAddress) as unknown as Observable<any>
+    )) as { contract: string; data: `0x${string}`[]; messages: Record<number, { type: number }[]> }
 
-    expect(
-      updateBalanceSheetManagers.calledOnceWith([
-        {
-          centrifugeId: centId,
-          address: managerAddress,
-          canManage: true,
-        },
-      ])
-    ).to.be.true
+    expect(batch.contract).to.equal(hub)
+    expect(batch.data).to.have.length(2)
+    expect(decodeFunctionData({ abi: ABI.Hub, data: batch.data[0]! }).functionName).to.equal('updateBalanceSheetManager')
+    expect(decodeFunctionData({ abi: ABI.Hub, data: batch.data[1]! }).functionName).to.equal('updateContract')
   })
 })
 

--- a/src/entities/PoolNetwork.test.ts
+++ b/src/entities/PoolNetwork.test.ts
@@ -645,7 +645,7 @@ describe('PoolNetwork.deployOnchainPM', () => {
   })
 })
 
-describe('PoolNetwork.registerOnchainPMAsBSManager', () => {
+describe('PoolNetwork.authorizeOnchainPM', () => {
   const hub = '0xcccccccccccccccccccccccccccccccccccccccc'
   const accountingToken = '0xdddddddddddddddddddddddddddddddddddddddd'
   const managerAddress = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' as const
@@ -684,7 +684,7 @@ describe('PoolNetwork.registerOnchainPMAsBSManager', () => {
     const pn = new PoolNetwork(root as any, pool, centId)
 
     const batch = (await lastValueFrom(
-      pn.registerOnchainPMAsBSManager(managerAddress) as unknown as Observable<any>
+      pn.authorizeOnchainPM(managerAddress) as unknown as Observable<any>
     )) as { contract: string; data: `0x${string}`[]; messages: Record<number, { type: number }[]> }
 
     expect(batch.contract).to.equal(hub)

--- a/src/entities/PoolNetwork.ts
+++ b/src/entities/PoolNetwork.ts
@@ -235,7 +235,7 @@ export class PoolNetwork extends Entity {
         }
       }
 
-      const result = yield* doTransaction('DeployOnchainPM', ctx, () =>
+      const result = yield* doTransaction('Deploy onchain PM', ctx, () =>
         ctx.walletClient.writeContract({
           address: onchainPMFactory,
           abi: ABI.OnchainPMFactory,
@@ -315,7 +315,7 @@ export class PoolNetwork extends Entity {
         ],
       })
 
-      yield* wrapTransaction('Register OnchainPM as balance sheet manager', ctx, {
+      yield* wrapTransaction('Authorize onchain PM', ctx, {
         contract: hub,
         data: [registerManagerCall, grantMinterCall],
         messages: {

--- a/src/entities/PoolNetwork.ts
+++ b/src/entities/PoolNetwork.ts
@@ -1,5 +1,5 @@
 import { combineLatest, concat, defer, EMPTY, firstValueFrom, map, of, switchMap } from 'rxjs'
-import { encodeFunctionData, getContract, maxUint128 } from 'viem'
+import { encodeAbiParameters, encodeFunctionData, getContract, maxUint128 } from 'viem'
 import { ABI } from '../abi/index.js'
 import type { Centrifuge } from '../Centrifuge.js'
 import { NULL_ADDRESS, SAFE_PROXY_BYTECODE } from '../constants.js'
@@ -261,18 +261,70 @@ export class PoolNetwork extends Entity {
   }
 
   /**
-   * Register a deployed OnchainPM as a Balance Sheet Manager on the hub chain.
-   * Use this with the address obtained from deployOnchainPM().
+   * Register a deployed OnchainPM as a Balance Sheet Manager on the hub chain
+   * and, in the same batched transaction, grant it minter rights on the pool's
+   * accounting token (workflows that mint/burn accounting tokens need this).
+   *
+   * Both calls are batched into a single `Hub` transaction signed on the hub
+   * chain. The minter grant is routed `Hub.updateContract` → Spoke
+   * `contractUpdater` → `AccountingToken.trustedCall`, which decodes
+   * `abi.encode(bytes32 who, bool canMint)`.
+   *
    * @param managerAddress - The deployed OnchainPM contract address
+   * @param scId - Share class used for the accounting-token `updateContract`
+   *   routing. The minter mapping is pool-wide, so any of the pool's share
+   *   classes works; defaults to the pool's first share class.
    */
-  registerOnchainPMAsBSManager(managerAddress: HexString) {
-    return this.pool.updateBalanceSheetManagers([
-      {
-        centrifugeId: this.centrifugeId,
-        address: managerAddress,
-        canManage: true,
-      },
-    ])
+  registerOnchainPMAsBSManager(managerAddress: HexString, scId?: HexString) {
+    const self = this
+    return this._transact(async function* (ctx) {
+      assertCrosschainMessagingEnabled(self.centrifugeId)
+
+      const { hub } = await self._root._protocolAddresses(self.pool.centrifugeId)
+      const { accountingToken } = await self._root._protocolAddresses(self.centrifugeId)
+
+      const resolvedScId = scId ?? (await firstValueFrom(self.pool.shareClasses()))[0]?.id.raw
+      if (!resolvedScId) {
+        throw new Error('No share class found for pool to route the accounting-token minter update')
+      }
+
+      // 1. Register the OnchainPM as a balance sheet manager.
+      const registerManagerCall = encodeFunctionData({
+        abi: ABI.Hub,
+        functionName: 'updateBalanceSheetManager',
+        args: [self.pool.id.raw, self.centrifugeId, addressToBytes32(managerAddress), true, ctx.signingAddress],
+      })
+
+      // 2. Grant the OnchainPM minter rights on the accounting token.
+      const minterPayload = encodeAbiParameters(
+        [{ type: 'bytes32' }, { type: 'bool' }],
+        [addressToBytes32(managerAddress), true]
+      )
+      const grantMinterCall = encodeFunctionData({
+        abi: ABI.Hub,
+        functionName: 'updateContract',
+        args: [
+          self.pool.id.raw,
+          resolvedScId,
+          self.centrifugeId,
+          addressToBytes32(accountingToken),
+          minterPayload,
+          0n,
+          ctx.signingAddress,
+        ],
+      })
+
+      yield* wrapTransaction('Register OnchainPM as balance sheet manager', ctx, {
+        contract: hub,
+        data: [registerManagerCall, grantMinterCall],
+        messages: {
+          [self.centrifugeId]: [
+            { type: MessageType.UpdateBalanceSheetManager, poolId: self.pool.id },
+            { type: MessageType.TrustedContractUpdate, poolId: self.pool.id },
+          ],
+        },
+      })
+    }, this.pool.centrifugeId)
   }
 
   /**

--- a/src/entities/PoolNetwork.ts
+++ b/src/entities/PoolNetwork.ts
@@ -261,9 +261,10 @@ export class PoolNetwork extends Entity {
   }
 
   /**
-   * Register a deployed OnchainPM as a Balance Sheet Manager on the hub chain
-   * and, in the same batched transaction, grant it minter rights on the pool's
-   * accounting token (workflows that mint/burn accounting tokens need this).
+   * Authorize a deployed OnchainPM for this pool. Registers it as a Balance
+   * Sheet Manager on the hub chain and, in the same batched transaction, grants
+   * it minter rights on the pool's accounting token (workflows that mint/burn
+   * accounting tokens need this).
    *
    * Both calls are batched into a single `Hub` transaction signed on the hub
    * chain. The minter grant is routed `Hub.updateContract` → Spoke
@@ -275,7 +276,7 @@ export class PoolNetwork extends Entity {
    *   routing. The minter mapping is pool-wide, so any of the pool's share
    *   classes works; defaults to the pool's first share class.
    */
-  registerOnchainPMAsBSManager(managerAddress: HexString, scId?: HexString) {
+  authorizeOnchainPM(managerAddress: HexString, scId?: HexString) {
     const self = this
     return this._transact(async function* (ctx) {
       assertCrosschainMessagingEnabled(self.centrifugeId)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -94,6 +94,8 @@ export type ProtocolContracts = {
   merkleProofManagerFactory: HexString
   onOfframpManagerFactory: HexString
   onchainPMFactory: HexString
+  /** ERC-6909 accounting token used by OnchainPM workflows. Minter perms are keyed by pool. */
+  accountingToken: HexString
   tokenRecoverer: HexString
   contractUpdater: HexString
   vaultDecoder: HexString


### PR DESCRIPTION
## Summary

When authorizing a deployed `OnchainPM` for a pool, also grant it **minter rights on the pool's accounting token** — batched into the same hub transaction. Workflows that mint/burn accounting tokens require the OnchainPM to be a minter, so this removes a manual follow-up step after deploy.

### Changes
- Renamed **`PoolNetwork.registerOnchainPMAsBSManager` → `authorizeOnchainPM(managerAddress, scId?)`** — it now does more than register a balance sheet manager, so the old name no longer fit.
- `authorizeOnchainPM` submits a single batched `Hub` transaction with two calls:
  1. `updateBalanceSheetManager` (unchanged behavior)
  2. `updateContract` → Spoke `contractUpdater` → `AccountingToken.trustedCall`, payload `abi.encode(bytes32 who, bool canMint)` granting the OnchainPM as minter.

  The optional `scId` (defaults to the pool's first share class) is only used for Hub routing — the accounting-token minter mapping is keyed by pool, not share class.
- Added **`accountingToken`** to `ProtocolContracts`, plus a testnet shim (`TESTNET_ACCOUNTING_TOKEN_BY_CENTRIFUGE_ID`, hardcoded to `0x4D0c…1AEd`) alongside the existing OnchainPM-factory shim until the indexer exposes the address.

### Notes
- The minter grant is keyed by `minters[poolId][who]` on `AccountingToken`; `CastLib.toAddress` reads the high 20 bytes, so the address is right-padded via `addressToBytes32`.
- Updated the `authorizeOnchainPM` test to assert the batched calldata (two `Hub` calls). Typecheck + the affected mocha tests pass.

### Consumer follow-up
apps-v3 (#1057) calls the old `registerOnchainPMAsBSManager` and will be updated to `authorizeOnchainPM(address, scId?)` once this merges.
