### PR TITLE
feat: runtime input token/source links + testnet marketplace release

### DIFF
--- a/src/Centrifuge.ts
+++ b/src/Centrifuge.ts
@@ -49,7 +49,8 @@ import type {
 import { PoolMetadataInput } from './types/poolInput.js'
 import { PoolMetadata } from './types/poolMetadata.js'
 import type { CentrifugeQueryOptions, Query } from './types/query.js'
-import type { CatalogAction, MarketplaceWorkflow } from './types/workflow.js'
+import type { CatalogAction, MarketplaceWorkflow, RuntimeVariable } from './types/workflow.js'
+import { runtimeVariableName } from './types/workflow.js'
 import {
   emptyMessage,
   MessageType,
@@ -81,7 +82,7 @@ const PINNING_API_DEMO = 'https://europe-central2-peak-vista-185616.cloudfunctio
 // CIDs are in the GitHub release notes: https://github.com/centrifuge/workflows/releases
 const WORKFLOW_MARKETPLACE_CID: Record<string, string> = {
   mainnet: 'QmQp1KEDPGpKQ7tVzqq92sAJ61tjfSi58FHCTjCEnvePQ7',
-  testnet: 'QmR2xdN56iJPNPVnBgZiy8WyVqKPvHtfg7JbXyHYqJs6Gx',
+  testnet: 'QmTNi5CAuxhubqJQMyt9tcDhuoWCx6FmEDygkhqkqUjJr8',
 }
 
 // Temporary testnet shim until the indexer exposes Deployment.onchainPMFactory.
@@ -973,13 +974,20 @@ export class Centrifuge {
         const res = await fetch(url)
         if (!res.ok) throw new Error(`workflowMarketplace: IPFS fetch failed — ${res.status} ${res.statusText}`)
         const catalog = await res.json()
-        const templates: Record<string, { actions: CatalogAction[]; runtimeVariables?: string[] }> =
+        const templates: Record<string, { actions: CatalogAction[]; runtimeVariables?: RuntimeVariable[] }> =
           catalog.templates ?? {}
         const rawWorkflows: unknown[] = Array.isArray(catalog) ? catalog : (catalog.workflows ?? [])
         return rawWorkflows
           .filter((w: any) => !w.useTemplate)
-          .map(
-            (w: any): MarketplaceWorkflow => ({
+          .map((w: any): MarketplaceWorkflow => {
+            // runtimeVariables may be the legacy `string[]` or the object form
+            // `{ name, token?, source? }[]` (centrifuge/workflows #84). Keep the full
+            // entries for the UI, and a normalized name list for everything else.
+            const runtimeVariableEntries: RuntimeVariable[] =
+              (Array.isArray(w.runtimeVariables) ? w.runtimeVariables : undefined) ??
+              templates[w.template]?.runtimeVariables ??
+              []
+            return {
               workflowRef: w.id ?? w.workflowRef,
               name: w.name,
               template: w.template,
@@ -994,12 +1002,10 @@ export class Centrifuge {
               useTemplate: w.useTemplate,
               templates,
               actions: templates[w.template]?.actions ?? [],
-              runtimeVariables:
-                (Array.isArray(w.runtimeVariables) ? w.runtimeVariables : undefined) ??
-                templates[w.template]?.runtimeVariables ??
-                [],
-            })
-          )
+              runtimeVariables: runtimeVariableEntries.map(runtimeVariableName),
+              runtimeVariableEntries,
+            }
+          })
       })
     )
   }

--- a/src/entities/ShareClass.ts
+++ b/src/entities/ShareClass.ts
@@ -233,7 +233,12 @@ export class ShareClass extends Entity {
           if (res.length === 0) {
             return of([])
           }
-          const items = res.filter((item) => Number(item.centrifugeId) === centrifugeId || !centrifugeId)
+          const items = res.filter(
+            // Skip holdings whose asset metadata isn't indexed yet (`asset` is null):
+            // they can't be priced/rendered, and reading `asset.address` below would
+            // otherwise throw and fail the whole `balances()` stream.
+            (item) => (Number(item.centrifugeId) === centrifugeId || !centrifugeId) && item.asset != null
+          )
 
           if (items.length === 0) return of([])
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,15 @@ export * from './entities/ShareClass.js'
 export * from './entities/Vault.js'
 export type { Client, Config, CurrencyDetails, HexString } from './types/index.js'
 export type { IssuerDetail, PoolMetadataInput, PoolReport, ShareClassInput } from './types/poolInput.js'
-export type { ActionDefinition, CatalogAction, CatalogActionInput, InputDefinition, MarketplaceWorkflow } from './types/workflow.js'
+export type {
+  ActionDefinition,
+  CatalogAction,
+  CatalogActionInput,
+  InputDefinition,
+  MarketplaceWorkflow,
+  RuntimeVariable,
+} from './types/workflow.js'
+export { runtimeVariableName } from './types/workflow.js'
 export * from './types/poolMetadata.js'
 export type { Query } from './types/query.js'
 export type {

--- a/src/types/workflow.ts
+++ b/src/types/workflow.ts
@@ -80,10 +80,24 @@ export interface CatalogAction {
   returns?: string
 }
 
+/**
+ * A runtime input declaration. The legacy form is a bare variable name; the
+ * object form (centrifuge/workflows #84) additionally links an amount input to
+ * its denominating `token` (for decimals/symbol) and the `source` holder address
+ * whose balance bounds the max. `token`/`source` are `$`-references to declared,
+ * magic, or runtime variables.
+ */
+export type RuntimeVariable = string | { name: string; token?: string; source?: string }
+
+/** Normalize a {@link RuntimeVariable} to its bare-or-`$`-prefixed name. */
+export function runtimeVariableName(variable: RuntimeVariable): string {
+  return typeof variable === 'string' ? variable : variable.name
+}
+
 /** A reusable action template from the marketplace catalog. */
 export interface CatalogTemplate {
   actions: CatalogAction[]
-  runtimeVariables?: string[]
+  runtimeVariables?: RuntimeVariable[]
   id?: string
 }
 
@@ -123,6 +137,11 @@ export interface MarketplaceWorkflow {
   templates?: Record<string, CatalogTemplate>
   /** Human-readable contract call steps resolved from the template. */
   actions: CatalogAction[]
-  /** Runtime inputs supplied by the executor when the workflow runs. */
+  /** Runtime inputs supplied by the executor when the workflow runs (names only). */
   runtimeVariables?: string[]
+  /**
+   * Full runtime input declarations, preserving the optional `token`/`source`
+   * links from the object form. Aligned 1:1 with `runtimeVariables` by name.
+   */
+  runtimeVariableEntries?: RuntimeVariable[]
 }

--- a/src/utils/catalog.ts
+++ b/src/utils/catalog.ts
@@ -1,6 +1,7 @@
 import { toFunctionSelector } from 'viem'
 import type { HexString } from '../types/index.js'
 import type { CatalogAction, CatalogActionInput, CatalogTemplate, MarketplaceWorkflow } from '../types/workflow.js'
+import { runtimeVariableName } from '../types/workflow.js'
 import { MAGIC_VARIABLE_KEYS } from './variables.js'
 import { CALL, UNUSED_SLOT, VALUECALL } from './weiroll.js'
 import type { WeirollAction, WorkflowDefinition, WorkflowStateSlot } from './weiroll.js'
@@ -426,7 +427,7 @@ export function buildWorkflowDefinitionFromCatalog(
           workflowId: '',
           templates,
           actions: applyUseTemplateMap(template.actions, inp.useTemplate.map ?? {}),
-          runtimeVariables: template.runtimeVariables ?? [],
+          runtimeVariables: (template.runtimeVariables ?? []).map(runtimeVariableName),
         }
         const templateDefinition = buildWorkflowDefinitionFromCatalog(templateWorkflow, { templates })
         return getOrAddSlot(`template:${actionIndex}:${inputIndex}:${templateName}`, {


### PR DESCRIPTION
Supports the new runtime-input format from [centrifuge/workflows#84](https://github.com/centrifuge/workflows/pull/84) and bumps the testnet marketplace release.

## Changes
- **Testnet marketplace CID** → `QmTNi5CAuxhubqJQMyt9tcDhuoWCx6FmEDygkhqkqUjJr8`.
- **`RuntimeVariable` type** — `string | { name, token?, source? }`. The object form links an amount input to its denominating `token` (decimals/symbol) and the `source` holder address (whose balance bounds the max). `token`/`source` are `$`-refs to declared/magic/runtime variables.
- **`MarketplaceWorkflow.runtimeVariables`** stays a normalized **name list** (backward-compatible with every existing `string[]` consumer — weiroll, `buildWorkflowDefinitionFromCatalog`, etc.).
- **`MarketplaceWorkflow.runtimeVariableEntries`** (new) carries the full entries with the `token`/`source` links for the UI.
- Template-callback `runtimeVariables` are normalized to names so the object form never reaches the string-only paths.

Consumed by the app to render runtime amount inputs as a balance input (decimals from `token`, max from `balanceOf(token, source)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)