### PR TITLE
feat: add invest-app fund-fact fields and new apy vocabulary to pool metadata types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@centrifuge/sdk",
-  "version": "1.12.2",
+  "version": "1.13.0",
   "description": "",
   "homepage": "https://github.com/centrifuge/sdk/tree/main#readme",
   "author": "",

--- a/src/types/poolInput.ts
+++ b/src/types/poolInput.ts
@@ -1,5 +1,5 @@
 import { HexString } from './index.js'
-import { PoolMetadata } from './poolMetadata.js'
+import { ApyMode, LegacyApyMode, PoolMetadata } from './poolMetadata.js'
 
 export type FileType = { uri: string; mime: string }
 
@@ -16,7 +16,7 @@ export type ShareClassInput = {
   symbolName: string
   minInvestment?: number | null
   apyPercentage?: number | null
-  apy?: 'target' | '7day' | '30day' | '90day' | 'ytd' | 'sinceInception' | 'automatic' | null
+  apy?: ApyMode | LegacyApyMode | null
   salt?: string
   defaultAccounts?: PoolMetadata['shareClasses'][HexString]['defaultAccounts']
 }

--- a/src/types/poolMetadata.ts
+++ b/src/types/poolMetadata.ts
@@ -2,6 +2,33 @@ import { HexString } from './index.js'
 
 export type FileType = { uri: string; mime: string }
 
+/**
+ * APY display modes read by the invest app: an indexer yield window (7d/30d/90d/180d) combined
+ * with a day-count basis (365/360), optionally compounded (30d only), the windowless modes
+ * ttm/ytd/sinceInception, or 'none' to hide APY entirely.
+ */
+export type ApyMode =
+  | '7d365'
+  | '7d360'
+  | '30d365'
+  | '30d360'
+  | '30dComp365'
+  | '30dComp360'
+  | '90d365'
+  | '90d360'
+  | '180d365'
+  | '180d360'
+  | 'ttm'
+  | 'ytd'
+  | 'sinceInception'
+  | 'none'
+
+/**
+ * @deprecated No longer recognized by the invest app — these fall back to '30d365'. Kept in the
+ * union so metadata documents that predate the new vocabulary still type-check when read.
+ */
+export type LegacyApyMode = 'target' | '7day' | '30day' | '90day' | 'automatic'
+
 export type MerkleProofWorkflow = {
   id: string
   name: string
@@ -149,14 +176,23 @@ export type PoolMetadata = {
       reportUrl?: string
       reportFile?: FileType | null
     }[]
+    /** Expense ratio in percent, kept as a string, e.g. '0.25' */
+    expenseRatio?: string
   }
   shareClasses: Record<
     HexString,
     {
       icon?: FileType | null
       minInitialInvestment?: number | null
+      /** Fallback APY in percent, shown while the indexer has no computed yield yet */
       apyPercentage?: number | null
-      apy?: 'target' | '7day' | '30day' | '90day' | 'ytd' | 'sinceInception' | 'automatic' | null
+      apy?: ApyMode | LegacyApyMode | null
+      /** Weighted average asset maturity in days, e.g. 63.33; row hidden in the invest app when unset */
+      weightedAverageMaturity?: number | null
+      /** Past year performance in percent, e.g. 4.1; row hidden in the invest app when unset */
+      pastYearPerformance?: number | null
+      /** 'underlying' for wrapper tokens whose performance track record predates the wrapper */
+      pastYearPerformanceSource?: 'fund' | 'underlying' | null
       defaultAccounts?: {
         asset?: number
         equity?: number

--- a/src/types/poolMetadata.ts
+++ b/src/types/poolMetadata.ts
@@ -5,7 +5,8 @@ export type FileType = { uri: string; mime: string }
 /**
  * APY display modes read by the invest app: an indexer yield window (7d/30d/90d/180d) combined
  * with a day-count basis (365/360), optionally compounded (30d only), the windowless modes
- * ttm/ytd/sinceInception, or 'none' to hide APY entirely.
+ * ttm/ytd/sinceInception, 'fixed' to display the hardcoded apyPercentage as the APY, or 'none'
+ * to hide APY entirely.
  */
 export type ApyMode =
   | '7d365'
@@ -21,6 +22,7 @@ export type ApyMode =
   | 'ttm'
   | 'ytd'
   | 'sinceInception'
+  | 'fixed'
   | 'none'
 
 /**


### PR DESCRIPTION
## What

Type-only change bringing `PoolMetadata` / `ShareClassInput` up to date with the fund facts the invest app reads from pool metadata (apps-invest-v3#186):

- **`ApyMode`** — the new `apy` display vocabulary: a yield window (`7d`/`30d`/`90d`/`180d`) combined with a day-count basis (`365`/`360`), optionally compounded (30d only: `30dComp365`/`30dComp360`), the windowless modes `ttm`/`ytd`/`sinceInception`, and `none` to hide APY entirely.
- **`LegacyApyMode`** *(deprecated)* — the previous values (`target`, `7day`, `30day`, `90day`, `automatic`). The invest app no longer recognizes them and falls back to `30d365`, but they remain in the union so existing metadata documents still type-check when read.
- **New share class fields**: `weightedAverageMaturity` (days), `pastYearPerformance` (percent), `pastYearPerformanceSource` (`'fund' | 'underlying'` — `underlying` for wrapper tokens like deJAAA whose track record predates the wrapper).
- **`pool.expenseRatio`** — percent kept as a string, e.g. `'0.25'`.

`ShareClassInput.apy` (used by `pool.update()`) is widened to the same union so callers can pass stored values through without casts.

## Why

The management app is shipping a pool metadata editor (centrifuge/apps-v3#1079, issue apps-v3#1078) and currently has to maintain a local `PoolMetadataExtended` type with `as unknown as PoolMetadata` casts at the `updateMetadata` boundary because the SDK type predates these fields. Once this is released, that workaround gets deleted.

## Notes

- No runtime behavior change — types only. `tsc --noEmit` passes.
- `ShareClass.details()` and `Pool.update()` inherit the widened union automatically since they derive from these types.