### PR TITLE
feat: add apyTooltip to share class metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@centrifuge/sdk",
-  "version": "1.13.2",
+  "version": "1.14.0",
   "description": "",
   "homepage": "https://github.com/centrifuge/sdk/tree/main#readme",
   "author": "",

--- a/src/types/poolMetadata.ts
+++ b/src/types/poolMetadata.ts
@@ -189,7 +189,10 @@ export type PoolMetadata = {
       /** Fallback APY in percent, shown while the indexer has no computed yield yet */
       apyPercentage?: number | null
       apy?: ApyMode | LegacyApyMode | null
-      /** Free-text tooltip shown by the invest app alongside the APY; used with apy: 'fixed' */
+      /**
+       * Free-text tooltip shown by the invest app alongside the APY; used with apy: 'fixed' to
+       * explain the hardcoded apyPercentage (e.g. "Target APY set by the fund manager").
+       */
       apyTooltip?: string | null
       /** Weighted average asset maturity in days, e.g. 63.33; row hidden in the invest app when unset */
       weightedAverageMaturity?: number | null

--- a/src/types/poolMetadata.ts
+++ b/src/types/poolMetadata.ts
@@ -189,6 +189,8 @@ export type PoolMetadata = {
       /** Fallback APY in percent, shown while the indexer has no computed yield yet */
       apyPercentage?: number | null
       apy?: ApyMode | LegacyApyMode | null
+      /** Free-text tooltip shown by the invest app alongside the APY; used with apy: 'fixed' */
+      apyTooltip?: string | null
       /** Weighted average asset maturity in days, e.g. 63.33; row hidden in the invest app when unset */
       weightedAverageMaturity?: number | null
       /** Past year performance in percent, e.g. 4.1; row hidden in the invest app when unset */


### PR DESCRIPTION
## What

Adds `apyTooltip?: string | null` to `PoolMetadata.shareClasses[scId]`.

It's a free-text tooltip the invest app shows alongside the APY. It pairs with the `apy: 'fixed'` mode (centrifuge/sdk#465) — when a fund displays a hardcoded `apyPercentage` rather than an indexer-computed yield, `apyTooltip` lets operations explain it (e.g. "Target APY set by the fund manager").

## Why

The management app's pool metadata editor (centrifuge/apps-v3#1079) is adding a tooltip text input that appears when APY display is set to Fixed. The invest app will read this field for the APY tooltip (centrifuge/apps-invest-v3#188).

## Notes

- Type-only change, no runtime behavior. `tsc --noEmit` passes, Prettier clean.