### PR TITLE
fix: skip notifyPool when a share class is already active on the chain

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@centrifuge/sdk",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "description": "",
   "homepage": "https://github.com/centrifuge/sdk/tree/main#readme",
   "author": "",

--- a/src/entities/PoolNetwork.ts
+++ b/src/entities/PoolNetwork.ts
@@ -819,8 +819,12 @@ export class PoolNetwork extends Entity {
         }
       }
 
-      // notifyPool must come before the other pool-related messages, because they depend on the pool being active
-      if (!details.isActive) {
+      // notifyPool must come before the other pool-related messages, because they depend on the pool
+      // being active. Only do it on the first deployment to this chain: once any share class is
+      // active here the pool is already registered, and re-notifying it (e.g. when deploying a second
+      // share class to the same chain) reverts. `activeShareClasses` is treated as authoritative since
+      // an active share class implies an active pool even if `isActive` lags.
+      if (!details.isActive && details.activeShareClasses.length === 0) {
         batch.push(
           encodeFunctionData({
             abi: ABI.Hub,


### PR DESCRIPTION
Related: centrifuge/apps-v3#1084

## Problem

Deploying a **second** share class to a chain where the pool is **already active** (because a first share class is deployed there) fails. `PoolNetwork.deploy` gated `notifyPool` only on `!details.isActive`:

```ts
if (!details.isActive) {
  batch.push(encode('notifyPool', …))
}
```

`notifyPool` registers/activates the pool on a chain. On the second share-class deploy the pool is already registered, so the redundant `notifyPool` reverts (observed on mainnet as a `0x3caf4585` revert in a `multicall([notifyPool, notifyShareClass])`).

The adapters block just above already guards on "first deployment to this chain" via `details.activeShareClasses.length === 0`, but the `notifyPool` block didn't — so the two got out of sync.

## Fix

Only emit `notifyPool` on the first deployment to a chain — i.e. when there are no active share classes there yet:

```ts
if (!details.isActive && details.activeShareClasses.length === 0) { … }
```

An active share class on a chain implies the pool is active there, so this also covers cases where `isActive` lags the actual on-chain state. First-time deploys (no active share classes, pool not active) are unchanged.