### PR TITLE
feat: adapterStatus() + re-enable Plume cross-chain messaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@centrifuge/sdk",
-  "version": "1.14.1",
+  "version": "1.15.0",
   "description": "",
   "homepage": "https://github.com/centrifuge/sdk/tree/main#readme",
   "author": "",

--- a/src/entities/Pool.ts
+++ b/src/entities/Pool.ts
@@ -1117,6 +1117,62 @@ export class Pool extends Entity {
   }
 
   /**
+   * Per-adapter live + in-flight state for this pool on the spoke→hub route,
+   * from the indexer. `isEnabled` is the set confirmed live on the spoke;
+   * `crosschainInProgress` flags an adapter whose enable/disable was triggered
+   * on the hub but has not yet been confirmed on the spoke (`null` once settled).
+   *
+   * Unlike `adapters()` — which reads the hub MultiAdapter and so reports a
+   * triggered change as already active — this reflects what is actually live
+   * versus still in transit.
+   *
+   * @param centrifugeId - The centrifuge ID of the spoke network
+   */
+  adapterStatus(centrifugeId: CentrifugeId) {
+    return this._query(['adapterStatus', this.id.toString(), centrifugeId, this.centrifugeId], () =>
+      this._root
+        ._queryIndexer<{
+          poolAdapters: {
+            items: {
+              adapterAddress: HexString
+              isEnabled: boolean | null
+              crosschainInProgress: 'Enabled' | 'Disabled' | null
+              adapter: { name: string } | null
+            }[]
+          }
+        }>(
+          `query ($poolId: BigInt!, $local: String!, $remote: String!) {
+            poolAdapters(where: { poolId: $poolId, localCentrifugeId: $local, remoteCentrifugeId: $remote }) {
+              items {
+                adapterAddress
+                isEnabled
+                crosschainInProgress
+                adapter {
+                  name
+                }
+              }
+            }
+          }`,
+          {
+            poolId: this.id.toString(),
+            local: String(centrifugeId),
+            remote: String(this.centrifugeId),
+          }
+        )
+        .pipe(
+          map(({ poolAdapters }) =>
+            poolAdapters.items.map((item) => ({
+              address: item.adapterAddress.toLowerCase() as HexString,
+              name: item.adapter?.name ?? 'unknown',
+              isEnabled: !!item.isEnabled,
+              crosschainInProgress: item.crosschainInProgress ?? null,
+            }))
+          )
+        )
+    )
+  }
+
+  /**
    * Query cross-chain messages (indexer-side: `CrosschainPayload`) for this
    * pool. Without a filter, returns the most recent batch across all routes
    * and statuses; `filter.status` is the common case (e.g. `'InTransit'` for

--- a/src/entities/Pool.ts
+++ b/src/entities/Pool.ts
@@ -5,6 +5,7 @@ import type { Centrifuge } from '../Centrifuge.js'
 import { HexString } from '../types/index.js'
 import { PoolMetadataInput, ShareClassInput } from '../types/poolInput.js'
 import { PoolMetadata, WorkflowPolicyEntry } from '../types/poolMetadata.js'
+import type { Query } from '../types/query.js'
 import { MessageType, MessageTypeWithSubType } from '../types/transaction.js'
 import { NATIONAL_CURRENCY_METADATA } from '../utils/currencies.js'
 import {
@@ -23,6 +24,23 @@ import { PoolNetwork } from './PoolNetwork.js'
 import { PoolReports } from './Reports/PoolReports.js'
 import { ShareClass } from './ShareClass.js'
 import { queryCrosschainMessages, type CrosschainMessagesFilter } from './crosschainMessages.js'
+
+/**
+ * In-flight state of a cross-chain adapter change. `'Enabled'` / `'Disabled'`
+ * is the target state of a change triggered on the hub but not yet confirmed on
+ * the spoke; `null` means the adapter is settled (no change in transit).
+ */
+export type AdapterProgress = 'Enabled' | 'Disabled' | null
+
+/** Per-adapter live + in-flight state for a pool, as returned by {@link Pool.adapterStatus}. */
+export type AdapterStatus = {
+  address: HexString
+  /** Indexer adapter name, e.g. `chainlink`, `layerZero`, `axelar`, `wormhole`. */
+  name: string
+  /** The live, confirmed state on the queried (spoke) chain. */
+  isEnabled: boolean
+  crosschainInProgress: AdapterProgress
+}
 
 export class Pool extends Entity {
   id: PoolId
@@ -1128,7 +1146,7 @@ export class Pool extends Entity {
    *
    * @param centrifugeId - The centrifuge ID of the spoke network
    */
-  adapterStatus(centrifugeId: CentrifugeId) {
+  adapterStatus(centrifugeId: CentrifugeId): Query<AdapterStatus[]> {
     return this._query(['adapterStatus', this.id.toString(), centrifugeId, this.centrifugeId], () =>
       this._root
         ._queryIndexer<{
@@ -1136,7 +1154,7 @@ export class Pool extends Entity {
             items: {
               adapterAddress: HexString
               isEnabled: boolean | null
-              crosschainInProgress: 'Enabled' | 'Disabled' | null
+              crosschainInProgress: AdapterProgress
               adapter: { name: string } | null
             }[]
           }
@@ -1160,12 +1178,12 @@ export class Pool extends Entity {
           }
         )
         .pipe(
-          map(({ poolAdapters }) =>
+          map(({ poolAdapters }): AdapterStatus[] =>
             poolAdapters.items.map((item) => ({
               address: item.adapterAddress.toLowerCase() as HexString,
               name: item.adapter?.name ?? 'unknown',
               isEnabled: !!item.isEnabled,
-              crosschainInProgress: item.crosschainInProgress ?? null,
+              crosschainInProgress: item.crosschainInProgress,
             }))
           )
         )

--- a/src/utils/crosschainHotfix.test.ts
+++ b/src/utils/crosschainHotfix.test.ts
@@ -11,7 +11,9 @@ import {
 describe('crosschainHotfix', () => {
   const poolId = PoolId.from(1, 1)
 
-  it('skips messages targeting Plume', () => {
+  // The disabled list is currently empty, so all targets (including Plume) are
+  // enabled. These tests document that and exercise the kill-switch helpers.
+  it('allows messages to all networks when nothing is disabled', () => {
     const messages: Record<number, MessageTypeWithSubType[]> = {
       1: [{ type: MessageType.NotifyPricePoolPerShare, poolId }],
     }
@@ -21,19 +23,17 @@ describe('crosschainHotfix', () => {
       poolId,
     })
 
-    expect(added).to.equal(false)
-    expect(messages).to.have.keys(['1'])
+    expect(added).to.equal(true)
+    expect(messages[PLUME_CENTRIFUGE_ID]).to.have.length(1)
   })
 
-  it('throws before estimating or submitting Plume messages', () => {
-    expect(() => assertCrosschainMessagingEnabled(PLUME_CENTRIFUGE_ID)).to.throw(
-      `Cross-chain messaging for centrifugeId ${PLUME_CENTRIFUGE_ID} is temporarily disabled`
-    )
+  it('does not throw for any target when nothing is disabled', () => {
+    expect(() => assertCrosschainMessagingEnabled(PLUME_CENTRIFUGE_ID)).to.not.throw()
 
     expect(() =>
       assertMessagesDoNotTargetDisabledChains({
         [PLUME_CENTRIFUGE_ID]: [{ type: MessageType.NotifyPricePoolPerShare, poolId }],
       })
-    ).to.throw(`Cross-chain messaging for centrifugeId ${PLUME_CENTRIFUGE_ID} is temporarily disabled`)
+    ).to.not.throw()
   })
 })

--- a/src/utils/crosschainHotfix.ts
+++ b/src/utils/crosschainHotfix.ts
@@ -3,9 +3,11 @@ import type { CentrifugeId } from './types.js'
 
 export const PLUME_CENTRIFUGE_ID = 4
 
-// Temporary production hotfix: Plume cross-chain messaging is disabled until the
-// protocol adapter wiring is fixed. Remove this allowlist once Ops confirms Plume.
-export const TEMPORARILY_DISABLED_CROSSCHAIN_CENTRIFUGE_IDS = [PLUME_CENTRIFUGE_ID] as const
+// Kill-switch for temporarily disabling cross-chain messaging to specific
+// networks (e.g. while a network's adapter wiring is being fixed). Currently
+// empty — all networks are enabled, including Plume. To disable a network
+// again, add its centrifugeId here.
+export const TEMPORARILY_DISABLED_CROSSCHAIN_CENTRIFUGE_IDS = [] as const
 
 const disabledCentrifugeIds = new Set<number>(TEMPORARILY_DISABLED_CROSSCHAIN_CENTRIFUGE_IDS)
 


### PR DESCRIPTION
## Summary

Two cross-chain adapter changes that unblock the Cross-chain settings tab in apps-v3:

1. **`Pool.adapterStatus(centrifugeId)`** — a new query for per-adapter *live vs in-flight* state, sourced from the indexer.
2. **Clear the temporarily-disabled cross-chain networks list** — re-enables Plume (`centrifugeId 4`) for `setAdapters` and other cross-chain messages.

## 1. `Pool.adapterStatus()`

`adapters()` reads the hub-side MultiAdapter, so a change triggered on the hub shows as already active even when it never reached the spoke. There was no way to tell *live* from *in-transit* adapter state.

`adapterStatus(centrifugeId)` queries the indexer `poolAdapters` entity on the spoke→hub route and returns:

```ts
{ address: HexString; name: string; isEnabled: boolean; crosschainInProgress: 'Enabled' | 'Disabled' | null }[]
```

- `isEnabled` — the set confirmed live on the spoke.
- `crosschainInProgress` — the target state of a change triggered on the hub but not yet confirmed on the spoke (`null` once settled).

Built on the existing `_queryIndexer` pattern (mirrors `_managers()`). Additive and safe to merge independently.

## 2. Clear the disabled-networks list (re-enable Plume)

`TEMPORARILY_DISABLED_CROSSCHAIN_CENTRIFUGE_IDS` is now empty, so `filterCrosschainEnabledTargets` / `addMessageForEnabledTarget` no longer strip Plume. The kill-switch mechanism and `PLUME_CENTRIFUGE_ID` are retained, so a network can be re-disabled by adding its id back. The unit tests now assert nothing is disabled.

> ⚠️ **Merge/release gate:** the disabled list existed because Plume's adapter wiring was broken (messages triggered on the hub never reached the spoke). **Only merge/release this once Ops confirms Plume's wiring is fixed** — otherwise cross-chain messages to Plume will be sent and get stuck again. If that confirmation isn't in yet, the `adapterStatus()` commit can be cherry-picked / merged on its own.

## Test plan

- [x] `pnpm build` (tsc) passes
- [x] `crosschainHotfix` unit tests pass (`2 passing`)
- [x] eslint clean on changed files
- [ ] Full suite via CI (local run needs Tenderly credentials for the global fork setup)

## Consumer

apps-v3 PR #1092 (cross-chain adapters settings tab) will switch from a direct indexer query to `pool.adapterStatus()` and depends on Plume being un-gated to save Plume adapters.
