### PR TITLE
feat: align cross-chain request descriptions with app order vocabulary

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@centrifuge/sdk",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "description": "",
   "homepage": "https://github.com/centrifuge/sdk/tree/main#readme",
   "author": "",

--- a/src/entities/crosschainMessageDescription.test.ts
+++ b/src/entities/crosschainMessageDescription.test.ts
@@ -104,6 +104,7 @@ describe('describeCrosschainMessage', () => {
     // A deposit/redeem request reads as an investment/redemption.
     expect(request('RedeemRequest')).to.equal('Redemption by 0xac4...032')
     expect(request('CancelDepositRequest')).to.equal('Cancel investment by 0xac4...032')
+    expect(request('CancelRedeemRequest')).to.equal('Cancel redemption by 0xac4...032')
     // Issuance/revocation read as the executed investment/redemption.
     expect(callback('IssuedShares')).to.equal('Executed investment')
     expect(callback('RevokedShares')).to.equal('Executed redemption')

--- a/src/entities/crosschainMessageDescription.test.ts
+++ b/src/entities/crosschainMessageDescription.test.ts
@@ -87,13 +87,31 @@ describe('describeCrosschainMessage', () => {
         messageType: 'Request',
         data: { decodedPayload: { type: 'DepositRequest', data: { investor: ADDRESS } } },
       })
-    ).to.equal('Deposit request by 0xac4...032')
+    ).to.equal('Investment by 0xac4...032')
     expect(
       describeCrosschainMessage({
         messageType: 'RequestCallback',
         data: { decodedPayload: { type: 'FulfilledDepositRequest' } },
       })
-    ).to.equal('Fulfilled deposit request')
+    ).to.equal('Unlock investment')
+  })
+
+  it('aligns Request/RequestCallback labels with the app order vocabulary', () => {
+    const request = (type: string) =>
+      describeCrosschainMessage({ messageType: 'Request', data: { decodedPayload: { type, data: { investor: ADDRESS } } } })
+    const callback = (type: string) =>
+      describeCrosschainMessage({ messageType: 'RequestCallback', data: { decodedPayload: { type } } })
+    // A deposit/redeem request reads as an investment/redemption.
+    expect(request('RedeemRequest')).to.equal('Redemption by 0xac4...032')
+    expect(request('CancelDepositRequest')).to.equal('Cancel investment by 0xac4...032')
+    // Issuance/revocation read as the executed investment/redemption.
+    expect(callback('IssuedShares')).to.equal('Executed investment')
+    expect(callback('RevokedShares')).to.equal('Executed redemption')
+    // Fulfilled callbacks read as "Unlock …".
+    expect(callback('FulfilledRedeemRequest')).to.equal('Unlock redemption')
+    expect(callback('FulfilledCancelDepositRequest')).to.equal('Unlock cancel investment')
+    // Unmapped variants still fall back to a de-camel-cased label.
+    expect(callback('ApprovedDeposits')).to.equal('Approved deposits')
   })
 
   it('un-camel-cases unknown message types instead of throwing', () => {

--- a/src/entities/crosschainMessageDescription.ts
+++ b/src/entities/crosschainMessageDescription.ts
@@ -168,6 +168,29 @@ function unCamelCase(value: string | undefined): string {
   return value.replace(/(?<!^)[A-Z]/g, (letter) => ` ${letter.toLowerCase()}`)
 }
 
+/**
+ * Investor-facing label for a `Request` / `RequestCallback` payload type, aligned with the
+ * app's order vocabulary (see centrifuge/apps-v3#1056):
+ * - a deposit/redeem request reads as an investment/redemption,
+ * - share issuance/revocation reads as the executed investment/redemption,
+ * - a `Fulfilled…` callback reads as `Unlock …` (the funds/shares become claimable).
+ *
+ * Unmapped types fall back to a de-camel-cased label.
+ */
+const REQUEST_TYPE_LABELS: Record<string, string> = {
+  IssuedShares: 'Executed investment',
+  RevokedShares: 'Executed redemption',
+}
+
+function requestLabel(type: string | undefined): string {
+  if (!type) return unCamelCase(type)
+  const mapped = REQUEST_TYPE_LABELS[type]
+  if (mapped) return mapped
+  const unlocked = type.startsWith('Fulfilled') ? `Unlock${type.slice('Fulfilled'.length)}` : type
+  const vocab = unlocked.replace('DepositRequest', 'Investment').replace('RedeemRequest', 'Redemption')
+  return unCamelCase(vocab)
+}
+
 function tokenLabel(ctx: CrosschainMessageDescriptionContext): string {
   return ctx.token?.name ?? ctx.token?.symbol ?? '[??]'
 }
@@ -278,12 +301,12 @@ export function describeCrosschainMessage(
 
     case 'Request': {
       const payload = decodedPayloadOf(message.data)
-      return `${unCamelCase(payload?.type)} by ${shortenAddress(payload?.data?.investor)}`
+      return `${requestLabel(payload?.type)} by ${shortenAddress(payload?.data?.investor)}`
     }
 
     case 'RequestCallback': {
       const payload = decodedPayloadOf(message.data)
-      return unCamelCase(payload?.type)
+      return requestLabel(payload?.type)
     }
 
     case 'SetRequestManager':


### PR DESCRIPTION
Aligns the human-readable cross-chain `Request` / `RequestCallback` descriptions (added in #466) with the investor order vocabulary from [apps-v3#1056](https://github.com/centrifuge/apps-v3/pull/1056).

### Resulting labels (`describeCrosschainMessage`)

| payload type | label |
|---|---|
| `DepositRequest` | Investment by `0x…` |
| `RedeemRequest` | Redemption by `0x…` |
| `CancelDepositRequest` | Cancel investment by `0x…` |
| `CancelRedeemRequest` | Cancel redemption by `0x…` |
| `IssuedShares` | Executed investment |
| `RevokedShares` | Executed redemption |
| `FulfilledDepositRequest` | Unlock investment |
| `FulfilledRedeemRequest` | Unlock redemption |
| `FulfilledCancelDepositRequest` | Unlock cancel investment |
| `ApprovedDeposits` / unmapped | de-camel-cased fallback (unchanged) |

A single `requestLabel` normalizer now serves both the `Request` and `RequestCallback` cases: a deposit/redeem request reads as an investment/redemption, issuance/revocation as the executed investment/redemption, and `Fulfilled…` callbacks as `Unlock …`. Unit tests cover the new labels.
