### PR TITLE
feat: build only api

### DIFF
--- a/.claude/docs/BUILD_ONLY_API.md
+++ b/.claude/docs/BUILD_ONLY_API.md
@@ -1,0 +1,424 @@
+# Build-Only Transaction API
+
+**Status:** Implemented (Phases 1–3; §8 pinning hardening tracked separately)
+**Author:** Jeremiah McCurdy
+**Date:** 2026-06-11
+**Related:** `centrifuge/backend` → `docs/design/sdk-vs-native-tx-builder.md`
+
+This document specifies a **build-only** transaction API for the SDK: a way to
+produce the **unsigned calldata** for any transaction-producing method without a
+signer, without simulation, and without broadcasting. It explains what it is,
+why the SDK needs it, what it solves, how it functions against the current
+internals, and a phased implementation strategy.
+
+For how to _use_ the SDK today, see [SDK_USAGE.md](./SDK_USAGE.md). For
+SDK-internal development conventions, see [CLAUDE.md](../CLAUDE.md).
+
+---
+
+## 1. What it is
+
+A first-class method that returns the raw, unsigned transaction envelope a
+method _would_ send, instead of signing and broadcasting it:
+
+```typescript
+const built = await centrifuge.buildOnly(pool.updatePoolMetadata(input))
+// built: BuiltTransaction
+// {
+//   centrifugeId: number
+//   chainId: number
+//   to: HexString            // target contract
+//   data: HexString          // calldata (multicall(bytes[]) when batched)
+//   value: bigint            // wei to send
+//   calls: BuiltCall[]       // decoded inner calls (one per wrapped call)
+//   messages?: Record<number, MessageTypeWithSubType[]>  // cross-chain msgs, for fee estimation
+// }
+```
+
+It is the inverse of the existing signing flow: every tx method already builds
+calldata internally and then signs it. `buildOnly` stops at the calldata.
+
+Key properties:
+
+- **No signer required.** It does not call `setSigner`, does not need an
+  account, and never touches a `WalletClient`.
+- **Side-effect-free on chain.** No broadcast, no nonce consumption.
+- **Runs the full build logic.** Marketplace catalog parsing, merkle-tree
+  construction, weiroll encoding, IPFS pinning, address resolution — all the
+  work that lives inside the method runs, because that work _is_ what produces
+  the bytes.
+- **Returns data, not an Observable.** Unlike `Transaction`, the result is a
+  plain awaited value — there is no lifecycle to subscribe to.
+
+## 2. Why the SDK needs it
+
+### 2.1 The driving consumer: the Centrifuge backend
+
+The `centrifuge/backend` repo (`apps/private-api`) is moving on-chain
+transaction construction out of the browser and into the backend, where
+transactions are signed via **Fordefi** (custodial, multi-approver) rather than
+a user's wallet. The backend's flow is: **build unsigned calldata → run policy /
+decode / simulate → route to Fordefi or WalletConnect → persist → broadcast.**
+
+The backend needs **only the first step** from the SDK — the unsigned bytes. It
+owns everything after that (custody, policy, auth, persistence), and that
+ownership must **not** leak into the SDK, because the SDK is the public interface
+external partners build on.
+
+Today the backend's options are both bad:
+
+1. **Re-implement encoding natively** (its current path). This duplicates the
+   most complex SDK logic — the workflow/marketplace/weiroll encoding in
+   `MerkleProofManager`, `catalog`, `weiroll`, `workflowExecute` (~100 KB of
+   code) — and forces byte-equal-fixture tests to chase every SDK release. This
+   is the maintenance burden the backend memo documents.
+2. **Abuse `batchTransactions([oneTx])`** as a de-facto build-only call. This
+   works (see §4) but depends on a side-effect of the batching machinery, still
+   requires a signer to be set, and treats an internal yield shape as a public
+   contract.
+
+A named `buildOnly` makes option 3 — _use the SDK as a calldata factory behind a
+clean API_ — the obvious choice.
+
+### 2.2 The general case: any non-EOA custody
+
+The need is not backend-specific. **Any** consumer that signs somewhere other
+than an in-process EOA/EIP-1193 wallet has the same shape:
+
+- custodial / MPC signers (Fordefi, Fireblocks, etc.)
+- multisig proposal flows (Safe) that want the raw tx to propose
+- offline / air-gapped signing
+- transaction simulation or gas analysis in tooling and tests
+- partners who present a "review the calldata before you sign" UX
+
+All of them want "give me the bytes; I'll handle signing." The SDK currently
+assumes the signer is reachable in-process. `buildOnly` removes that assumption
+for the construction step.
+
+## 3. What it solves
+
+| Problem today                                                           | With `buildOnly`                                                        |
+| ----------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| Complex encoding (workflows/weiroll) duplicated in downstream consumers | One source of truth — the SDK — invoked behind a stable method          |
+| "Build without signing" only available via the batching side-effect     | A named, documented, tested API with a typed return                     |
+| `_transact` requires a signer even when only building (see §4)          | No signer needed; construction is decoupled from signing                |
+| Downstream byte-equal fixture tests chase every SDK release             | Downstream pins the SDK version and consumes its output directly        |
+| Non-EOA custody (Fordefi, Safe, MPC) is awkward                         | First-class: get bytes → sign anywhere                                  |
+| In-house dogfooding of the partner-facing SDK is discouraged            | The backend becomes the first consumer of the partner-facing build path |
+
+It explicitly does **not** try to solve: signing, custody, policy enforcement,
+authorization, persistence, or broadcast. Those belong to the consumer. The SDK
+stays a calldata factory.
+
+## 4. How it functions against the current internals
+
+The build path already exists inside the SDK — `buildOnly` exposes it cleanly.
+Here is the relevant machinery as it stands.
+
+### 4.1 The existing build path (`wrapTransaction` batching branch)
+
+Every tx-producing method funnels through `wrapTransaction`
+(`src/utils/transaction.ts`). When `ctx.isBatching` is true it **yields the
+unsigned calldata instead of signing**:
+
+```typescript
+// src/utils/transaction.ts — wrapTransaction
+if (ctx.isBatching) {
+  yield {
+    contract,
+    data, // HexString[]
+    value: value_,
+    messages,
+  } // BatchTransactionData — this is unsigned calldata
+} else {
+  // ...doTransaction(): signs + broadcasts via walletClient
+}
+```
+
+`batchTransactions(title, [tx])` (`src/Centrifuge.ts`) sets `isBatching` and runs
+a transaction through this branch, so a single-element batch already produces
+`BatchTransactionData` without broadcasting. That is the mechanism `buildOnly`
+builds on.
+
+### 4.2 The gap: `_transact` still requires a signer when batching
+
+The batching branch does not sign, but `_transact` (`src/Centrifuge.ts`) is not
+yet signer-free:
+
+```typescript
+// src/Centrifuge.ts — _transact (abridged)
+const { signer } = self
+if (!signer) throw new Error('Signer not set') // ← throws even when only building
+
+let walletClient = isLocalAccount(signer) ? /* http */ : /* custom(signer) */
+const [address] = await walletClient.getAddresses()
+if (!address) throw new Error('No account selected')
+// ctx.signingAddress = address  ← some build callbacks read this (e.g. permit flows)
+```
+
+So today, building-without-signing still needs a signer set and an address
+resolved, and any method whose build step reads `ctx.signingAddress` (e.g.
+permit construction) needs that address. **Closing this gap is the core of the
+work** — and it is the main reason a dedicated API is better than continuing to
+lean on `batchTransactions`.
+
+### 4.3 Where build-time I/O happens
+
+Building is **not** pure — it does network I/O and must stay `async`:
+
+- deployment / protocol address resolution (`_protocolAddresses`, `getClient`)
+- IPFS pinning inside metadata-mutating methods (`config.pinJson`, e.g.
+  `MerkleProofManager.addPolicy`, `createPool`)
+- chain config / id resolution (`_idToChain`, `getChainConfig`)
+
+`buildOnly` therefore returns a `Promise<BuiltTransaction>`. The only things it
+must avoid are the **signer-dependent** steps (wallet client creation, address
+resolution, chain switching, `writeContract`/`sendTransaction`).
+
+### 4.4 Return shape
+
+`BuiltTransaction` normalizes the internal `BatchTransactionData` into a stable,
+documented envelope:
+
+- `data` is the single call's calldata, or `multicall(bytes[])` calldata when
+  more than one inner call is wrapped (mirrors `wrapTransaction`'s own
+  single-vs-multicall branch, so byte output matches what would have been sent).
+- `calls: BuiltCall[]` exposes each inner call (`{ to, data, value }`) so
+  consumers can decode/inspect a batch without re-parsing the multicall.
+- `messages` is carried through unchanged so consumers can run the same
+  cross-chain fee estimation the signing path does (`_estimate`).
+
+## 5. API surface
+
+```typescript
+export interface BuiltCall {
+  to: HexString
+  data: HexString
+  value: bigint
+}
+
+export interface BuiltTransaction {
+  centrifugeId: number
+  chainId: number
+  to: HexString
+  data: HexString
+  value: bigint
+  calls: BuiltCall[]
+  messages?: Record<number, MessageTypeWithSubType[]>
+}
+
+export interface BuildOnlyOptions {
+  /**
+   * Address to use as the build-time `signingAddress` for methods whose
+   * construction reads it (e.g. permit flows). Required only for those methods;
+   * no signing is performed with it. Validated as an address, never used to
+   * sign.
+   */
+  fromAddress?: HexString
+}
+
+declare class Centrifuge {
+  /**
+   * Build the unsigned calldata a transaction would send, without a signer and
+   * without broadcasting. Runs the full construction logic (encoding, merkle,
+   * weiroll, IPFS pinning) but performs no signing step.
+   */
+  buildOnly(tx: Transaction, options?: BuildOnlyOptions): Promise<BuiltTransaction>
+}
+```
+
+Usage (the backend's `SdkTxBuilder` adapter):
+
+```typescript
+const centrifuge = new Centrifuge({ environment, rpcUrls, ipfsUrl })
+const pool = await centrifuge.pool(poolId)
+
+const built = await centrifuge.buildOnly(pool.updatePoolMetadata(input))
+// → map BuiltTransaction to the backend's RawTx envelope, hand to Fordefi
+```
+
+No `setSigner` call. The backend then signs `built.data` via Fordefi entirely
+outside the SDK.
+
+## 6. Implementation strategy
+
+Phased so the SDK ships green at each step and the public surface is added last.
+
+### Phase 1 — Make the build path signer-optional (internal)
+
+The smallest change that unblocks everything. In `_transact`, allow a
+build/batching run with **no signer**:
+
+1. Add an internal "build mode" flag to the transaction context (reuse or sit
+   beside `isBatching`). In build mode:
+   - do **not** throw on a missing signer;
+   - do **not** create a `WalletClient`, resolve addresses, or switch chains;
+   - set `ctx.signingAddress` from `options.fromAddress` when provided, else a
+     well-defined zero/placeholder, and document that build-mode callbacks must
+     not assume a real signer.
+2. Audit the methods whose build callbacks read `ctx.signingAddress` (permit
+   flows are the known case — `src/utils/permit.ts`) and ensure they either work
+   from `fromAddress` or surface a clear error in build mode when it's omitted.
+3. Keep the signing path byte-for-byte unchanged — build mode is purely
+   additive.
+
+**Done when:** an internal test can drive a method through build mode with no
+signer set and get `BatchTransactionData` out.
+
+### Phase 2 — Add `buildOnly` and the `BuiltTransaction` envelope (public)
+
+1. Add `buildOnly(tx, options?)` on `Centrifuge`. It runs the transaction in
+   build mode, takes the first emitted `BatchTransactionData`, and normalizes it
+   into `BuiltTransaction` (compute single-call vs `multicall(bytes[])` `data`
+   exactly as `wrapTransaction` does, populate `calls`, carry `messages`, attach
+   `centrifugeId`/`chainId`).
+2. Export `BuiltTransaction`, `BuiltCall`, `BuildOnlyOptions` from
+   `src/index.ts`.
+3. Reuse the multicall-encoding helper from `wrapTransaction` (extract it if
+   needed) so `buildOnly` and the signing path can never diverge on byte output.
+
+**Done when:** `buildOnly(pool.updatePoolMetadata(...))` returns calldata
+byte-equal to what the signing path sends for the same inputs.
+
+### Phase 3 — Tests + docs
+
+1. **Byte-equality tests** per representative method: assert `buildOnly` output
+   equals the calldata the signing path produces (capture via the existing
+   fork-server / mocked clients used in `src/**/*.test.ts`). Cover at minimum a
+   simple call (`updatePoolMetadata`), a multicall batch, and a
+   weiroll/marketplace method (`MerkleProofManager`).
+2. **No-signer test:** `buildOnly` succeeds with no `setSigner` call.
+3. **`fromAddress` test:** a permit-dependent method builds correctly with
+   `fromAddress` and errors clearly without it.
+4. Document in [SDK_USAGE.md](./SDK_USAGE.md) under a "Build-only / custodial
+   signing" section, and reference it from the backend memo.
+
+### Phase 4 — Deprecate the batching idiom for build-only use (optional)
+
+Once `buildOnly` ships, note in docs that `batchTransactions([oneTx])` is not
+the supported way to obtain unsigned calldata. `batchTransactions` remains for
+its real purpose (composing a genuine multi-call batch).
+
+## 7. Design decisions & trade-offs
+
+- **Why a new method, not "just use `batchTransactions`."** The batching path
+  requires a signer (§4.2), couples callers to an internal yield shape, and
+  conflates "build one tx" with "compose a batch." A named API with a typed
+  return is the stable contract external partners and the backend can depend on.
+- **`async` return.** Building does real I/O (addresses, IPFS). Pretending
+  otherwise would be a lie; `Promise<BuiltTransaction>` is honest.
+- **`fromAddress` instead of a fake signer.** Some methods legitimately need the
+  sender address at build time (permit). Passing an address — explicitly never
+  used to sign — is cleaner than constructing a dummy signer just to read its
+  address.
+- **No simulation, no policy, no broadcast in scope.** Simulation already exists
+  on the signing path (`wrapTransaction(..., { simulate: true })`) and can be
+  surfaced separately if wanted; `buildOnly` deliberately stays minimal — bytes
+  only. Consumers layer their own simulation/policy on top.
+- **Custody stays out of the SDK.** `buildOnly` returns bytes and nothing about
+  _how_ they get signed. Fordefi, Safe, MPC, etc. live entirely in the consumer.
+  This is the boundary that keeps the partner-facing SDK clean.
+
+## 8. Parallel work: secure the SDK's default pinning endpoint
+
+This should be built **alongside** the build-only API, not after it. The
+build-only API and the pinning hardening together close a real, active security
+issue — a stored-XSS / HTML-injection vector on `https://ipfs.centrifuge.io/`
+(malicious SVG/HTML pinned, then served with an executable content type). The
+backend memo (`centrifuge/backend` → `docs/design/sdk-vs-native-tx-builder.md`
+§6) covers the consumer side; this section covers what the **SDK** must change.
+
+### The problem in the SDK
+
+The SDK ships an **open, unauthenticated write endpoint by default**. In
+[`src/utils/ipfs.ts`](../../src/utils/ipfs.ts), `createPinning` builds:
+
+```ts
+pinFile: (b64URI) => pinToApi(`${pinningApiUrl}/pinFile`, { method: 'POST' /* no auth header */ })
+pinJson: (json) => pinToApi(`${pinningApiUrl}/pinJson`, { method: 'POST' /* no auth header */ })
+```
+
+and the default `pinningApiUrl` is a public cloud function
+(`PINNING_API_DEMO` in [`src/Centrifuge.ts`](../../src/Centrifuge.ts)). Because
+`apps-v3` constructs `new Centrifuge({...})` in the browser with no auth, **any
+visitor can replay the pinning calls** — and `pinFile` accepts an arbitrary
+base64 payload, which is the upload vector for the malicious content.
+
+`buildOnly` alone does **not** fix this. It moves _where_ pinning is invoked
+(into a backend), but as long as the SDK's default config ships an open write
+endpoint, every other consumer — and the SDK's own defaults — keeps the hole
+open.
+
+### Why it belongs with the build-only API
+
+The two changes are the same architectural move from two sides:
+
+- **`buildOnly`** lets a consumer run the build path (which calls `pinJson`)
+  server-side, behind its own auth.
+- **A pluggable, auth-capable pinning config** lets that server-side caller
+  inject a pinning function that holds the secret key and authenticates — instead
+  of the open demo endpoint.
+
+Shipping `buildOnly` without this leaves consumers building server-side but
+**still pinning through the open endpoint**, which defeats the security benefit.
+Ship them together.
+
+### What the SDK should change
+
+1. **Make pinning auth-capable, not just URL-configurable.** `pinJson`/`pinFile`
+   are already overridable via `Config`
+   ([`src/types/index.ts`](../../src/types/index.ts)) — good. Confirm a consumer
+   can fully replace them with an authenticated implementation (e.g. one that
+   attaches a bearer token / presigned request and points at a private pinning
+   service). Document this as the supported path for any non-public deployment.
+2. **Stop shipping an open write endpoint as the default.** Options, in
+   increasing strictness:
+   - default `pinJson`/`pinFile` to **throw** unless the consumer supplies a
+     pinning config ("no implicit public pinning") — safest, but a breaking
+     change;
+   - keep the demo endpoint but **clearly mark it demo/test-only** and require an
+     explicit opt-in flag to use it in `mainnet`;
+   - at minimum, document loudly that the default endpoint is unauthenticated and
+     must be replaced for any real deployment.
+     Recommendation: move toward "no implicit public pinning" on a major version,
+     with the demo endpoint behind an explicit opt-in until then.
+3. **Separate read gateway from write endpoint in config and docs.** `ipfsUrl`
+   (read/gateway) and the pinning endpoint (write) are different trust domains;
+   the docs and types should not blur them. (Note `getUrlFromHash` already
+   appends `?format=` to work around Pinata's SVG MIME handling — the same knob
+   the XSS abuses on read; the gateway content-type filter is the **consumer/
+   ops** side of the fix and is out of SDK scope, but the SDK should not
+   encourage relying on the open gateway for untrusted content.)
+4. **Surface `pinFile` constraints.** Where the SDK exposes `pinFile`, document
+   that callers are responsible for validating/whitelisting content types before
+   pinning; consider a typed/narrowed API for the metadata-pinning case so
+   arbitrary-file pinning is an explicit, separate, clearly-labeled capability.
+
+### Suggested phasing (interleaves with §6)
+
+- **With Phase 1/2:** confirm and document the auth-capable pinning override; add
+  a test that a consumer-supplied authenticated `pinJson` is used end-to-end by a
+  build-only call. (Unblocks the backend's `SdkTxBuilder` to pin securely.)
+- **With Phase 3:** docs in [SDK_USAGE.md](./SDK_USAGE.md) — a "Secure pinning"
+  section: never ship the default endpoint to production; how to inject an
+  authenticated pinner; read-gateway vs write-endpoint trust boundaries.
+- **Follow-up major:** the default-pinning behavior change (option 2 above),
+  coordinated with consumers so nothing silently loses pinning.
+
+### Out of SDK scope (record, don't own)
+
+The **read-side** fix — the gateway serving pinned bytes with a safe content
+type (Cloudflare/Pinata proxy content-type filter) — is an ops/infra concern,
+not an SDK change. The SDK's job here is to stop being the open **write** path
+and to not encourage trusting the open **read** gateway for untrusted content.
+
+## 9. Open questions for review
+
+- Exact set of methods that read `ctx.signingAddress` at build time — needs an
+  audit in Phase 1 (permit is known; confirm there are no others).
+- Whether `buildOnly` should accept an array (`Transaction[]`) to build a true
+  multicall in one call, or stay single-tx and let `batchTransactions` +
+  `buildOnly` compose. Recommendation: single-tx first; the multicall encoding
+  is already inside the batch path if needed later.
+- Whether to also expose a `simulate` convenience on the build result, or keep
+  simulation a separate concern (recommendation: separate, per §7).

--- a/.claude/docs/SDK_USAGE.md
+++ b/.claude/docs/SDK_USAGE.md
@@ -50,6 +50,72 @@ const account = privateKeyToAccount('0x...')
 centrifuge.setSigner(account)
 ```
 
+### Build-only / custodial signing
+
+When you sign somewhere other than an in-process EOA/EIP-1193 wallet — custodial
+or MPC signers (Fordefi, Fireblocks), Safe proposal flows, offline/air-gapped
+signing, or a "review the calldata before you sign" UX — use `buildOnly` to get
+the **unsigned calldata** a transaction method would send, without a signer and
+without broadcasting:
+
+```typescript
+const centrifuge = new Centrifuge({ environment, rpcUrls })
+const pool = await centrifuge.pool(poolId)
+
+// No setSigner() call needed.
+const built = await centrifuge.buildOnly(pool.updateMetadata(metadata))
+// built: { centrifugeId, chainId, to, data, value, calls, messages? }
+
+// Hand built.data to your custodial signer (Fordefi, Safe, MPC) entirely
+// outside the SDK, then broadcast it yourself.
+```
+
+`buildOnly` runs the full construction logic — encoding, merkle-tree
+construction, weiroll, IPFS pinning, address resolution — because that work _is_
+what produces the bytes. It only skips the signer-dependent steps (wallet-client
+creation, address resolution, chain switching, broadcast). Because the signing
+path and `buildOnly` share the same calldata encoder, `built.data` is
+byte-for-byte identical to what the signing path would send for the same inputs.
+
+It returns a plain `Promise<BuiltTransaction>` (not an Observable) — there is no
+transaction lifecycle to subscribe to, only the resulting bytes.
+
+```typescript
+interface BuiltCall {
+  to: HexString
+  data: HexString
+  value: bigint
+}
+interface BuiltTransaction {
+  centrifugeId: number
+  chainId: number
+  to: HexString // target contract
+  data: HexString // calldata (multicall(bytes[]) when batched)
+  value: bigint // wei to send
+  calls: BuiltCall[] // decoded inner calls (one per wrapped call)
+  messages?: Record<number, MessageTypeWithSubType[]> // cross-chain msgs, for fee estimation
+}
+```
+
+Some methods read the sender address at build time (e.g. permit flows). Pass it
+via `options.fromAddress` — it is validated as an address and **never used to
+sign**; when omitted, the zero address is used:
+
+```typescript
+const built = await centrifuge.buildOnly(tx, { fromAddress: '0xYourSender...' })
+```
+
+Notes and limitations:
+
+- **No signing, custody, policy, or broadcast.** `buildOnly` returns bytes and
+  nothing about how they get signed. Those belong to the consumer.
+- **Works only for methods that route through `wrapTransaction`** (the same
+  constraint as `batchTransactions`). Methods that broadcast via `doTransaction`
+  directly cannot be built without a signer.
+- `batchTransactions([oneTx])` is **not** the supported way to obtain unsigned
+  calldata — use `buildOnly`. `batchTransactions` remains for composing a genuine
+  multi-call batch.
+
 ## Entity Reference
 
 ### Pool - Pool management and configuration

--- a/.claude/docs/SDK_USAGE.md
+++ b/.claude/docs/SDK_USAGE.md
@@ -105,6 +105,15 @@ sign**; when omitted, the zero address is used:
 const built = await centrifuge.buildOnly(tx, { fromAddress: '0xYourSender...' })
 ```
 
+> **Note on the default.** When `fromAddress` is omitted, `buildOnly` does **not**
+> error — it silently embeds the zero address as `signingAddress`. For a method
+> whose construction bakes the sender into the calldata (permit flows, anything
+> that records `ctx.signingAddress` on-chain), that produces valid-looking bytes
+> with the wrong sender. **Always pass `fromAddress` for sender-dependent
+> methods.** Methods that genuinely need to _sign_ at build time (off-chain
+> permit signatures) cannot be built at all and will throw a descriptive error if
+> their build callback dereferences `walletClient`/`signer`.
+
 Notes and limitations:
 
 - **No signing, custody, policy, or broadcast.** `buildOnly` returns bytes and

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@centrifuge/sdk",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "",
   "homepage": "https://github.com/centrifuge/sdk/tree/main#readme",
   "author": "",

--- a/src/Centrifuge.ts
+++ b/src/Centrifuge.ts
@@ -1269,6 +1269,16 @@ export class Centrifuge {
           self.getChainConfig(centrifugeId),
           self.getClient(centrifugeId),
         ])
+        // `walletClient`/`signer` are never available in build mode (no signer is
+        // set). Rather than hand out `undefined` casts that surface as opaque
+        // TypeErrors, expose throwing getters so any accidental dereference fails
+        // with a descriptive message that points at the cause.
+        const throwInBuildMode = (field: 'walletClient' | 'signer'): never => {
+          throw new Error(
+            `Cannot access \`${field}\` in build-only mode: buildOnly() runs without a signer. ` +
+              `This method needs to sign and cannot be built. Use a method that routes through wrapTransaction.`
+          )
+        }
         const transaction = transactionCallback({
           isBatching: true,
           isBuilding: true,
@@ -1276,10 +1286,12 @@ export class Centrifuge {
           chain,
           centrifugeId,
           publicClient,
-          // Not used in build mode — wrapTransaction's batching branch never
-          // touches the wallet client. Present only to satisfy the context type.
-          walletClient: undefined as unknown as WalletClient<any, Chain, Account>,
-          signer: undefined as unknown as Signer,
+          get walletClient(): WalletClient<any, Chain, Account> {
+            return throwInBuildMode('walletClient')
+          },
+          get signer(): Signer {
+            return throwInBuildMode('signer')
+          },
           root: self,
         })
         if (Symbol.asyncIterator in transaction) {
@@ -1450,7 +1462,7 @@ export class Centrifuge {
     // produce (relevant for any method that embeds the address in calldata).
     this.#buildOnly.set(tx, { fromAddress: getAddress(fromAddress) })
 
-    const built = (await firstValueFrom(tx.pipe(first()))) as unknown as BatchTransactionData
+    const built = (await firstValueFrom(tx)) as unknown as BatchTransactionData
     if (!built || !built.contract || !built.data) {
       throw new Error('buildOnly: transaction did not produce build-only calldata (does it use wrapTransaction?)')
     }

--- a/src/Centrifuge.ts
+++ b/src/Centrifuge.ts
@@ -1462,7 +1462,18 @@ export class Centrifuge {
     // produce (relevant for any method that embeds the address in calldata).
     this.#buildOnly.set(tx, { fromAddress: getAddress(fromAddress) })
 
-    const built = (await firstValueFrom(tx)) as unknown as BatchTransactionData
+    // The flag is consumed on first use and always removed afterwards. `$tx` is
+    // `defer(transact)`, so every subscription re-runs the generator and re-reads
+    // this WeakMap; leaving the flag set would make a later subscription (e.g.
+    // `await tx` to actually sign) silently re-enter build mode and yield
+    // `BatchTransactionData` where `OperationStatus` is expected. `finally`
+    // guarantees cleanup even when the build callback throws.
+    let built: BatchTransactionData
+    try {
+      built = (await firstValueFrom(tx)) as unknown as BatchTransactionData
+    } finally {
+      this.#buildOnly.delete(tx)
+    }
     if (!built || !built.contract || !built.data) {
       throw new Error('buildOnly: transaction did not produce build-only calldata (does it use wrapTransaction?)')
     }

--- a/src/Centrifuge.ts
+++ b/src/Centrifuge.ts
@@ -3,6 +3,7 @@ import {
   defer,
   filter,
   first,
+  firstValueFrom,
   identity,
   isObservable,
   map,
@@ -20,11 +21,14 @@ import {
   custom,
   encodeFunctionData,
   fallback,
+  getAddress,
   getContract,
   http,
+  isAddress,
   keccak256,
   parseAbi,
   toHex,
+  zeroAddress,
   type Account,
   type Chain,
   type WalletClient,
@@ -62,6 +66,9 @@ import {
   emptyMessage,
   MessageType,
   MessageTypeWithSubType,
+  type BuildOnlyOptions,
+  type BuiltCall,
+  type BuiltTransaction,
   type OperationStatus,
   type Signer,
   type Transaction,
@@ -78,6 +85,7 @@ import { makeThenable, repeatOnEvents, shareReplayWithDelayedReset } from './uti
 import {
   BatchTransactionData,
   doTransaction,
+  encodeBatchCalldata,
   isLocalAccount,
   parseEventLogs,
   wrapTransaction,
@@ -174,6 +182,11 @@ export class Centrifuge {
   }
 
   #isBatching = new WeakSet<Transaction>()
+  // Transactions flagged for build-only mode, with the optional build-time
+  // `fromAddress` used as `ctx.signingAddress` (see `buildOnly`). Build mode
+  // reuses `wrapTransaction`'s batching branch to emit unsigned calldata, so a
+  // build-flagged tx is also treated as batching internally.
+  #buildOnly = new WeakMap<Transaction, { fromAddress: HexString }>()
 
   constructor(config: UserProvidedConfig = {}) {
     const defaultConfigForEnv = envConfig[config?.environment || 'mainnet']
@@ -1245,6 +1258,40 @@ export class Centrifuge {
   ): Transaction {
     const self = this
     async function* transact() {
+      const buildOnly = self.#buildOnly.get($tx)
+      // Build-only mode: produce unsigned calldata via wrapTransaction's batching
+      // branch. No signer, wallet client, address resolution, chain switching, or
+      // broadcast — only the I/O the construction itself needs (addresses, IPFS,
+      // public reads). `signingAddress` comes from `fromAddress` (defaults to the
+      // zero address); build callbacks must not assume a real signer.
+      if (buildOnly) {
+        const [chain, publicClient] = await Promise.all([
+          self.getChainConfig(centrifugeId),
+          self.getClient(centrifugeId),
+        ])
+        const transaction = transactionCallback({
+          isBatching: true,
+          isBuilding: true,
+          signingAddress: buildOnly.fromAddress,
+          chain,
+          centrifugeId,
+          publicClient,
+          // Not used in build mode — wrapTransaction's batching branch never
+          // touches the wallet client. Present only to satisfy the context type.
+          walletClient: undefined as unknown as WalletClient<any, Chain, Account>,
+          signer: undefined as unknown as Signer,
+          root: self,
+        })
+        if (Symbol.asyncIterator in transaction) {
+          yield* transaction
+        } else if (isObservable(transaction)) {
+          yield transaction
+        } else {
+          throw new Error('Invalid arguments')
+        }
+        return
+      }
+
       let isBatching = false
       if (self.#isBatching.has($tx)) {
         isBatching = true
@@ -1366,6 +1413,67 @@ export class Centrifuge {
    */
   batchTransactions(title: string, transactions: Transaction[]): Transaction {
     return this._experimental_batch(title, transactions)
+  }
+
+  /**
+   * Build the unsigned calldata a transaction would send, without a signer and
+   * without broadcasting. Runs the full construction logic (encoding, merkle,
+   * weiroll, IPFS pinning, address resolution) but performs no signing step —
+   * no `setSigner` is required and no nonce is consumed.
+   *
+   * Returns a plain `Promise<BuiltTransaction>` (not an Observable): there is no
+   * transaction lifecycle to subscribe to, only the resulting bytes.
+   *
+   * Building does real I/O (protocol addresses, IPFS pinning), so it is async.
+   * Only signer-dependent steps are skipped. Methods whose construction reads
+   * the sender address (e.g. permit flows) read `options.fromAddress`; when it
+   * is omitted the zero address is used.
+   *
+   * Works only for methods that route through `wrapTransaction` (the same
+   * constraint as `batchTransactions`); methods that call `doTransaction`
+   * directly cannot be built without a signer.
+   *
+   * @example
+   * ```ts
+   * const centrifuge = new Centrifuge({ environment, rpcUrls })
+   * const pool = await centrifuge.pool(poolId)
+   * const built = await centrifuge.buildOnly(pool.updateMetadata(metadata))
+   * // hand built.data to a custodial signer (Fordefi, Safe, MPC) outside the SDK
+   * ```
+   */
+  async buildOnly(tx: Transaction, options?: BuildOnlyOptions): Promise<BuiltTransaction> {
+    const fromAddress = options?.fromAddress ?? zeroAddress
+    if (!isAddress(fromAddress)) {
+      throw new Error(`buildOnly: invalid fromAddress "${fromAddress}"`)
+    }
+    // Checksum so the build-time signingAddress matches what a real wallet would
+    // produce (relevant for any method that embeds the address in calldata).
+    this.#buildOnly.set(tx, { fromAddress: getAddress(fromAddress) })
+
+    const built = (await firstValueFrom(tx.pipe(first()))) as unknown as BatchTransactionData
+    if (!built || !built.contract || !built.data) {
+      throw new Error('buildOnly: transaction did not produce build-only calldata (does it use wrapTransaction?)')
+    }
+
+    const chainId = await this._idToChain(tx.centrifugeId)
+    const value = built.value ?? 0n
+    const calls: BuiltCall[] = built.data.map((data) => ({
+      to: built.contract,
+      data,
+      // The protocol's multicall is non-payable per inner call; the whole-tx
+      // `value` rides on the outer call, so per-call value is 0.
+      value: 0n,
+    }))
+
+    return {
+      centrifugeId: tx.centrifugeId,
+      chainId,
+      to: built.contract,
+      data: encodeBatchCalldata(built.data),
+      value,
+      calls,
+      ...(built.messages ? { messages: built.messages } : {}),
+    }
   }
 
   /** @internal */

--- a/src/abi/Multicall.abi.ts
+++ b/src/abi/Multicall.abi.ts
@@ -1,0 +1,5 @@
+// Generic `multicall(bytes[])` fragment shared by every protocol contract that
+// supports batching (Hub, BalanceSheet, VaultRouter, …). Used for encoding batch
+// calldata in one place (`encodeBatchCalldata`) so it is not coupled to any one
+// contract's ABI.
+export default ['function multicall(bytes[] data) payable'] as const

--- a/src/abi/index.ts
+++ b/src/abi/index.ts
@@ -14,6 +14,7 @@ import HubRegistryAbi from './HubRegistry.abi.js'
 import MerkleProofManagerAbi from './MerkleProofManager.abi.js'
 import MerkleProofManagerFactoryAbi from './MerkleProofManagerFactory.abi.js'
 import MessageDispatcherAbi from './MessageDispatcher.abi.js'
+import MulticallAbi from './Multicall.abi.js'
 import OnchainPMAbi from './OnchainPM.abi.js'
 import OnchainPMFactoryAbi from './OnchainPMFactory.abi.js'
 import OracleValuationAbi from './OracleValuation.abi.js'
@@ -63,4 +64,5 @@ export const ABI = {
   OnchainPMFactory: parseAbi(OnchainPMFactoryAbi),
   OracleValuation: parseAbi(OracleValuationAbi),
   ScriptHelpers: parseAbi(ScriptHelpersAbi),
+  Multicall: parseAbi(MulticallAbi),
 }

--- a/src/buildOnly.test.ts
+++ b/src/buildOnly.test.ts
@@ -1,0 +1,189 @@
+import { expect } from 'chai'
+import { of } from 'rxjs'
+import sinon from 'sinon'
+import { encodeFunctionData, getAddress, parseAbi, zeroAddress } from 'viem'
+import { sepolia } from 'viem/chains'
+import { Centrifuge } from './Centrifuge.js'
+import { randomAddress } from './tests/utils.js'
+import { HexString } from './types/index.js'
+import { MessageType, MessageTypeWithSubType } from './types/transaction.js'
+import { makeThenable } from './utils/rx.js'
+import { wrapTransaction } from './utils/transaction.js'
+
+const chainId = sepolia.id
+const centId = 1
+
+// A tiny ABI used to produce deterministic calldata for the byte-equality checks.
+const TEST_ABI = parseAbi([
+  'function setValue(uint256 v)',
+  'function setOwner(address owner)',
+  'function multicall(bytes[] data) payable',
+])
+
+/**
+ * Stub the chain-resolution methods so a real `_transact` build run can resolve
+ * its `centrifugeId -> chainId` and clients without an indexer or a Tenderly
+ * fork. `wrapTransaction`'s batching branch — which build mode uses — never
+ * touches the (absent) wallet client, so these stubs are all the I/O it needs.
+ */
+function stubChain(centrifuge: Centrifuge) {
+  // `buildOnly` and `_transact` await these, so return thenable values. The real
+  // methods return awaitable Query observables; a bare `of(...)` is not thenable,
+  // so use a thenable that yields the value when awaited.
+  const thenable = <T>(value: T) => makeThenable(of(value))
+  sinon.stub(centrifuge as any, '_idToChain').returns(thenable(chainId))
+  sinon.stub(centrifuge as any, 'getChainConfig').returns(thenable(sepolia))
+  sinon.stub(centrifuge as any, 'getClient').returns(thenable({} as any))
+}
+
+describe('buildOnly', () => {
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  it('builds calldata with no signer set', async () => {
+    const centrifuge = new Centrifuge({ environment: 'testnet' })
+    stubChain(centrifuge)
+    const contract = randomAddress()
+    const data = encodeFunctionData({ abi: TEST_ABI, functionName: 'setValue', args: [42n] })
+
+    const tx = (centrifuge as any)._transact(async function* (ctx: any) {
+      yield* wrapTransaction('Set value', ctx, { contract, data })
+    }, centId)
+
+    expect(centrifuge.signer).to.equal(null)
+    const built = await centrifuge.buildOnly(tx)
+
+    expect(built.to.toLowerCase()).to.equal(contract.toLowerCase())
+    expect(built.data).to.equal(data)
+    expect(built.value).to.equal(0n)
+    expect(built.centrifugeId).to.equal(centId)
+    expect(built.chainId).to.equal(chainId)
+    expect(built.calls).to.have.length(1)
+    expect(built.calls[0]!.data).to.equal(data)
+  })
+
+  it('produces byte-equal calldata for a single call', async () => {
+    const centrifuge = new Centrifuge({ environment: 'testnet' })
+    stubChain(centrifuge)
+    const contract = randomAddress()
+    const data = encodeFunctionData({ abi: TEST_ABI, functionName: 'setValue', args: [7n] })
+
+    const tx = (centrifuge as any)._transact(async function* (ctx: any) {
+      yield* wrapTransaction('Set value', ctx, { contract, data, value: 123n })
+    }, centId)
+
+    const built = await centrifuge.buildOnly(tx)
+    // Single call is sent verbatim — no multicall wrapper.
+    expect(built.data).to.equal(data)
+    expect(built.value).to.equal(123n)
+  })
+
+  it('wraps multiple inner calls in multicall(bytes[]) byte-equally', async () => {
+    const centrifuge = new Centrifuge({ environment: 'testnet' })
+    stubChain(centrifuge)
+    const contract = randomAddress()
+    const call1 = encodeFunctionData({ abi: TEST_ABI, functionName: 'setValue', args: [1n] })
+    const call2 = encodeFunctionData({ abi: TEST_ABI, functionName: 'setValue', args: [2n] })
+
+    const tx = (centrifuge as any)._transact(async function* (ctx: any) {
+      yield* wrapTransaction('Set values', ctx, { contract, data: [call1, call2] })
+    }, centId)
+
+    const built = await centrifuge.buildOnly(tx)
+    const expected = encodeFunctionData({ abi: TEST_ABI, functionName: 'multicall', args: [[call1, call2]] })
+    expect(built.data).to.equal(expected)
+    expect(built.calls).to.have.length(2)
+    expect(built.calls.map((c) => c.data)).to.eql([call1, call2])
+  })
+
+  it('uses the zero address as signingAddress when no fromAddress is given', async () => {
+    const centrifuge = new Centrifuge({ environment: 'testnet' })
+    stubChain(centrifuge)
+    const contract = randomAddress()
+    let seenSigningAddress: HexString | undefined
+
+    const tx = (centrifuge as any)._transact(async function* (ctx: any) {
+      seenSigningAddress = ctx.signingAddress
+      const data = encodeFunctionData({ abi: TEST_ABI, functionName: 'setOwner', args: [ctx.signingAddress] })
+      yield* wrapTransaction('Set owner', ctx, { contract, data })
+    }, centId)
+
+    const built = await centrifuge.buildOnly(tx)
+    expect(seenSigningAddress).to.equal(zeroAddress)
+    const expected = encodeFunctionData({ abi: TEST_ABI, functionName: 'setOwner', args: [zeroAddress] })
+    expect(built.data).to.equal(expected)
+  })
+
+  it('embeds a provided fromAddress as the build-time signingAddress', async () => {
+    const centrifuge = new Centrifuge({ environment: 'testnet' })
+    stubChain(centrifuge)
+    const contract = randomAddress()
+    const from = randomAddress()
+    let seenSigningAddress: HexString | undefined
+
+    const tx = (centrifuge as any)._transact(async function* (ctx: any) {
+      seenSigningAddress = ctx.signingAddress
+      const data = encodeFunctionData({ abi: TEST_ABI, functionName: 'setOwner', args: [ctx.signingAddress] })
+      yield* wrapTransaction('Set owner', ctx, { contract, data })
+    }, centId)
+
+    const built = await centrifuge.buildOnly(tx, { fromAddress: from })
+    // Checksummed so it matches what a wallet would produce.
+    expect(seenSigningAddress).to.equal(getAddress(from))
+    const expected = encodeFunctionData({ abi: TEST_ABI, functionName: 'setOwner', args: [getAddress(from)] })
+    expect(built.data).to.equal(expected)
+  })
+
+  it('throws on an invalid fromAddress', async () => {
+    const centrifuge = new Centrifuge({ environment: 'testnet' })
+    stubChain(centrifuge)
+    const tx = (centrifuge as any)._transact(async function* (ctx: any) {
+      yield* wrapTransaction('Noop', ctx, { contract: randomAddress(), data: '0x' })
+    }, centId)
+
+    let error: unknown
+    try {
+      await centrifuge.buildOnly(tx, { fromAddress: 'not-an-address' as HexString })
+    } catch (e) {
+      error = e
+    }
+    expect(error).to.be.instanceOf(Error)
+    expect((error as Error).message).to.contain('invalid fromAddress')
+  })
+
+  it('carries cross-chain messages through for fee estimation', async () => {
+    const centrifuge = new Centrifuge({ environment: 'testnet' })
+    stubChain(centrifuge)
+    const contract = randomAddress()
+    const data = encodeFunctionData({ abi: TEST_ABI, functionName: 'setValue', args: [1n] })
+    const messages: Record<number, MessageTypeWithSubType[]> = { 2: [MessageType.RegisterAsset] }
+
+    const tx = (centrifuge as any)._transact(async function* (ctx: any) {
+      yield* wrapTransaction('With messages', ctx, { contract, data, messages })
+    }, centId)
+
+    const built = await centrifuge.buildOnly(tx)
+    expect(built.messages).to.eql(messages)
+  })
+
+  it('does not consume the signer when one is set', async () => {
+    const centrifuge = new Centrifuge({ environment: 'testnet' })
+    stubChain(centrifuge)
+    // A signer whose `request` would throw if the build path ever touched it.
+    const signer = {
+      request: sinon.stub().rejects(new Error('signer must not be used in build mode')),
+    }
+    centrifuge.setSigner(signer as any)
+    const contract = randomAddress()
+    const data = encodeFunctionData({ abi: TEST_ABI, functionName: 'setValue', args: [9n] })
+
+    const tx = (centrifuge as any)._transact(async function* (ctx: any) {
+      yield* wrapTransaction('Set value', ctx, { contract, data })
+    }, centId)
+
+    const built = await centrifuge.buildOnly(tx)
+    expect(built.data).to.equal(data)
+    expect(signer.request.called).to.equal(false)
+  })
+})

--- a/src/buildOnly.test.ts
+++ b/src/buildOnly.test.ts
@@ -167,6 +167,41 @@ describe('buildOnly', () => {
     expect(built.messages).to.eql(messages)
   })
 
+  it('throws a descriptive error if a build callback dereferences walletClient or signer', async () => {
+    const centrifuge = new Centrifuge({ environment: 'testnet' })
+    stubChain(centrifuge)
+
+    const walletTx = (centrifuge as any)._transact(async function* (ctx: any) {
+      // A method that needs to sign would touch the wallet client — invalid in build mode.
+      void ctx.walletClient
+      yield* wrapTransaction('Needs wallet', ctx, { contract: randomAddress(), data: '0x' })
+    }, centId)
+
+    let walletError: unknown
+    try {
+      await centrifuge.buildOnly(walletTx)
+    } catch (e) {
+      walletError = e
+    }
+    expect(walletError).to.be.instanceOf(Error)
+    expect((walletError as Error).message).to.contain('build-only mode')
+    expect((walletError as Error).message).to.contain('walletClient')
+
+    const signerTx = (centrifuge as any)._transact(async function* (ctx: any) {
+      void ctx.signer
+      yield* wrapTransaction('Needs signer', ctx, { contract: randomAddress(), data: '0x' })
+    }, centId)
+
+    let signerError: unknown
+    try {
+      await centrifuge.buildOnly(signerTx)
+    } catch (e) {
+      signerError = e
+    }
+    expect(signerError).to.be.instanceOf(Error)
+    expect((signerError as Error).message).to.contain('signer')
+  })
+
   it('does not consume the signer when one is set', async () => {
     const centrifuge = new Centrifuge({ environment: 'testnet' })
     stubChain(centrifuge)

--- a/src/buildOnly.test.ts
+++ b/src/buildOnly.test.ts
@@ -1,12 +1,16 @@
 import { expect } from 'chai'
 import { of } from 'rxjs'
 import sinon from 'sinon'
-import { encodeFunctionData, getAddress, parseAbi, zeroAddress } from 'viem'
+import { encodeFunctionData, getAddress, parseAbi, toHex, zeroAddress } from 'viem'
 import { sepolia } from 'viem/chains'
+import { ABI } from './abi/index.js'
 import { Centrifuge } from './Centrifuge.js'
+import { Pool } from './entities/Pool.js'
+import { mockPoolMetadata } from './tests/mocks/mockPoolMetadata.js'
 import { randomAddress } from './tests/utils.js'
 import { HexString } from './types/index.js'
 import { MessageType, MessageTypeWithSubType } from './types/transaction.js'
+import { PoolId } from './utils/types.js'
 import { makeThenable } from './utils/rx.js'
 import { wrapTransaction } from './utils/transaction.js'
 
@@ -220,5 +224,53 @@ describe('buildOnly', () => {
     const built = await centrifuge.buildOnly(tx)
     expect(built.data).to.equal(data)
     expect(signer.request.called).to.equal(false)
+  })
+
+  describe('real entity methods', () => {
+    const poolId = PoolId.from(centId, 1)
+    const hub = randomAddress()
+    const cid = 'QmTestCidForBuildOnlyMetadata'
+
+    // Drives a real entity method (Pool.updateMetadata) through buildOnly end to
+    // end — pinning + address resolution + wrapTransaction — and asserts the
+    // calldata is byte-equal to the known Hub.setPoolMetadata encoding. Stubs the
+    // network I/O (indexer/IPFS) so it runs in the fast suite without Tenderly.
+    function makeCentrifuge() {
+      const centrifuge = new Centrifuge({
+        environment: 'testnet',
+        // Deterministic pin so the encoded CID is known.
+        pinJson: async () => cid,
+      })
+      stubChain(centrifuge)
+      sinon.stub(centrifuge as any, '_protocolAddresses').returns(makeThenable(of({ hub } as any)))
+      return centrifuge
+    }
+
+    it('builds Pool.updateMetadata() byte-equal to the signing-path encoding', async () => {
+      const centrifuge = makeCentrifuge()
+      const pool = new Pool(centrifuge, poolId.raw)
+
+      const built = await centrifuge.buildOnly(pool.updateMetadata(mockPoolMetadata))
+
+      const expected = encodeFunctionData({
+        abi: ABI.Hub,
+        functionName: 'setPoolMetadata',
+        args: [poolId.raw, toHex(cid)],
+      })
+      expect(built.to.toLowerCase()).to.equal(hub.toLowerCase())
+      expect(built.data).to.equal(expected)
+      expect(built.value).to.equal(0n)
+      expect(built.chainId).to.equal(chainId)
+      expect(built.calls).to.have.length(1)
+      expect(built.calls[0]!.data).to.equal(expected)
+    })
+
+    it('builds a real entity method with no signer set', async () => {
+      const centrifuge = makeCentrifuge()
+      const pool = new Pool(centrifuge, poolId.raw)
+      expect(centrifuge.signer).to.equal(null)
+      const built = await centrifuge.buildOnly(pool.updateMetadata(mockPoolMetadata))
+      expect(built.data).to.match(/^0x/)
+    })
   })
 })

--- a/src/buildOnly.test.ts
+++ b/src/buildOnly.test.ts
@@ -226,6 +226,34 @@ describe('buildOnly', () => {
     expect(signer.request.called).to.equal(false)
   })
 
+  it('consumes the build-only flag so re-subscribing does not re-enter build mode', async () => {
+    const centrifuge = new Centrifuge({ environment: 'testnet' })
+    stubChain(centrifuge)
+    const contract = randomAddress()
+    const data = encodeFunctionData({ abi: TEST_ABI, functionName: 'setValue', args: [3n] })
+
+    const tx = (centrifuge as any)._transact(async function* (ctx: any) {
+      yield* wrapTransaction('Set value', ctx, { contract, data })
+    }, centId)
+
+    // First use builds successfully (no signer needed).
+    const built = await centrifuge.buildOnly(tx)
+    expect(built.data).to.equal(data)
+
+    // The flag is now consumed. `$tx` re-runs the generator on a fresh
+    // subscription; without cleanup it would silently re-enter build mode and
+    // emit BatchTransactionData. With cleanup it falls through to the signing
+    // path, which requires a signer — so it must error rather than build again.
+    let error: unknown
+    try {
+      await tx
+    } catch (e) {
+      error = e
+    }
+    expect(error).to.be.instanceOf(Error)
+    expect((error as Error).message).to.contain('Signer not set')
+  })
+
   describe('real entity methods', () => {
     const poolId = PoolId.from(centId, 1)
     const hub = randomAddress()

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,6 +65,7 @@ export type {
   OperationSignedMessageStatus,
   OperationSigningMessageStatus,
   OperationSigningStatus,
+  MessageTypeWithSubType,
   OperationStatus,
   OperationStatusType,
   OperationSwitchChainStatus,

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,9 @@ export * from './types/poolMetadata.js'
 export { migratePoolMetadataToV2, parsePoolMetadataV2, resolveLinkTarget } from './utils/poolMetadataMigration.js'
 export type { Query } from './types/query.js'
 export type {
+  BuildOnlyOptions,
+  BuiltCall,
+  BuiltTransaction,
   DeployedOnchainPMStatus,
   EIP1193ProviderLike,
   OperationConfirmedStatus,

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -140,8 +140,56 @@ export type Signer = EIP1193ProviderLike | LocalAccount
 
 export type Transaction = Query<OperationStatus> & { centrifugeId: number }
 
+/** A single decoded inner call within a {@link BuiltTransaction}. */
+export type BuiltCall = {
+  to: HexString
+  data: HexString
+  value: bigint
+}
+
+/**
+ * The unsigned transaction envelope produced by `Centrifuge.buildOnly`. It is
+ * the calldata a transaction method *would* send, with no signing or broadcast.
+ *
+ * - `data` is the single call's calldata, or `multicall(bytes[])` calldata when
+ *   more than one inner call is wrapped — byte-equal to what the signing path
+ *   would send for the same inputs.
+ * - `calls` exposes each inner call so consumers can inspect a batch without
+ *   re-parsing the multicall.
+ * - `messages` carries the cross-chain messages (if any) so consumers can run
+ *   the same fee estimation the signing path does.
+ */
+export type BuiltTransaction = {
+  centrifugeId: number
+  chainId: number
+  to: HexString
+  data: HexString
+  value: bigint
+  calls: BuiltCall[]
+  messages?: Record<number, MessageTypeWithSubType[]>
+}
+
+export type BuildOnlyOptions = {
+  /**
+   * Address to use as the build-time `signingAddress` for methods whose
+   * construction reads it (e.g. permit flows). Defaults to the zero address.
+   * No signing is performed with it — it is validated as an address and never
+   * used to sign.
+   */
+  fromAddress?: HexString
+}
+
 export type TransactionContext = {
   isBatching?: boolean
+  /**
+   * Build-only mode. When true, the transaction is run to produce unsigned
+   * calldata (via the `wrapTransaction` batching branch) and no signing,
+   * broadcasting, chain switching, or wallet-client interaction happens.
+   * In this mode `signer`/`walletClient` are not backed by a real signer and
+   * must not be used; build callbacks may read `signingAddress` (defaults to
+   * the zero address unless a `fromAddress` is supplied to `buildOnly`).
+   */
+  isBuilding?: boolean
   signingAddress: HexString
   chain: Chain
   centrifugeId: number

--- a/src/utils/transaction.test.ts
+++ b/src/utils/transaction.test.ts
@@ -1,0 +1,34 @@
+import { expect } from 'chai'
+import { encodeFunctionData, parseAbi } from 'viem'
+import { HexString } from '../types/index.js'
+import { encodeBatchCalldata } from './transaction.js'
+
+const ABI = parseAbi(['function setValue(uint256 v)', 'function multicall(bytes[] data) payable'])
+
+describe('encodeBatchCalldata', () => {
+  it('throws on an empty call list', () => {
+    expect(() => encodeBatchCalldata([])).to.throw('No calldata to encode')
+  })
+
+  it('returns a single call verbatim (no multicall wrapper)', () => {
+    const call = encodeFunctionData({ abi: ABI, functionName: 'setValue', args: [42n] })
+    expect(encodeBatchCalldata([call])).to.equal(call)
+  })
+
+  it('wraps two or more calls in multicall(bytes[])', () => {
+    const call1 = encodeFunctionData({ abi: ABI, functionName: 'setValue', args: [1n] })
+    const call2 = encodeFunctionData({ abi: ABI, functionName: 'setValue', args: [2n] })
+    const expected = encodeFunctionData({ abi: ABI, functionName: 'multicall', args: [[call1, call2]] })
+    expect(encodeBatchCalldata([call1, call2])).to.equal(expected)
+  })
+
+  it('preserves call order when wrapping', () => {
+    const a = encodeFunctionData({ abi: ABI, functionName: 'setValue', args: [10n] })
+    const b = encodeFunctionData({ abi: ABI, functionName: 'setValue', args: [20n] })
+    const c = encodeFunctionData({ abi: ABI, functionName: 'setValue', args: [30n] })
+    const forward = encodeBatchCalldata([a, b, c] as HexString[])
+    const reordered = encodeBatchCalldata([c, b, a] as HexString[])
+    expect(forward).to.not.equal(reordered)
+    expect(forward).to.equal(encodeFunctionData({ abi: ABI, functionName: 'multicall', args: [[a, b, c]] }))
+  })
+})

--- a/src/utils/transaction.test.ts
+++ b/src/utils/transaction.test.ts
@@ -1,7 +1,11 @@
 import { expect } from 'chai'
+import sinon from 'sinon'
 import { encodeFunctionData, parseAbi } from 'viem'
+import { sepolia } from 'viem/chains'
+import { randomAddress } from '../tests/utils.js'
 import { HexString } from '../types/index.js'
-import { encodeBatchCalldata } from './transaction.js'
+import type { OperationStatus, TransactionContext } from '../types/transaction.js'
+import { encodeBatchCalldata, wrapTransaction } from './transaction.js'
 
 const ABI = parseAbi(['function setValue(uint256 v)', 'function multicall(bytes[] data) payable'])
 
@@ -30,5 +34,86 @@ describe('encodeBatchCalldata', () => {
     const reordered = encodeBatchCalldata([c, b, a] as HexString[])
     expect(forward).to.not.equal(reordered)
     expect(forward).to.equal(encodeFunctionData({ abi: ABI, functionName: 'multicall', args: [[a, b, c]] }))
+  })
+})
+
+describe('wrapTransaction broadcast path', () => {
+  afterEach(() => sinon.restore())
+
+  const signingAddress = randomAddress()
+  const contract = randomAddress()
+  const txHash = '0xabc' as HexString
+
+  // Build a mock TransactionContext that drives the non-batching broadcast branch
+  // of wrapTransaction: a wallet client that records sendTransaction args, a
+  // public client whose receipt confirms success, and a root that resolves the
+  // chain so assertWalletChainMatches passes.
+  function makeCtx() {
+    const sendTransaction = sinon.stub().resolves(txHash)
+    const writeContract = sinon.stub().resolves(txHash)
+    const ctx = {
+      isBatching: false,
+      signingAddress,
+      centrifugeId: 1,
+      walletClient: {
+        getChainId: sinon.stub().resolves(sepolia.id),
+        sendTransaction,
+        writeContract,
+      },
+      publicClient: {
+        getCode: sinon.stub().resolves('0x'),
+        waitForTransactionReceipt: sinon.stub().resolves({ status: 'success' }),
+      },
+      root: {
+        _idToChain: sinon.stub().resolves(sepolia.id),
+      },
+    } as unknown as TransactionContext
+    return { ctx, sendTransaction, writeContract }
+  }
+
+  async function drain(gen: AsyncGenerator<OperationStatus | unknown>) {
+    const out: any[] = []
+    for await (const v of gen) out.push(v)
+    return out
+  }
+
+  it('broadcasts a single call verbatim via sendTransaction (no multicall wrapper)', async () => {
+    const { ctx, sendTransaction, writeContract } = makeCtx()
+    const data = encodeFunctionData({ abi: ABI, functionName: 'setValue', args: [42n] })
+
+    const statuses = await drain(wrapTransaction('Single', ctx, { contract, data, value: 5n }))
+
+    expect(writeContract.called).to.equal(false)
+    expect(sendTransaction.calledOnce).to.equal(true)
+    expect(sendTransaction.firstCall.args[0]).to.deep.equal({ to: contract, data, value: 5n })
+    expect(statuses.some((s) => s.type === 'TransactionConfirmed' && s.hash === txHash)).to.equal(true)
+  })
+
+  it('broadcasts multiple calls as multicall(bytes[]) calldata via sendTransaction', async () => {
+    const { ctx, sendTransaction, writeContract } = makeCtx()
+    const call1 = encodeFunctionData({ abi: ABI, functionName: 'setValue', args: [1n] })
+    const call2 = encodeFunctionData({ abi: ABI, functionName: 'setValue', args: [2n] })
+
+    await drain(wrapTransaction('Multi', ctx, { contract, data: [call1, call2] }))
+
+    // The multicall case no longer uses writeContract — it sends pre-encoded calldata.
+    expect(writeContract.called).to.equal(false)
+    expect(sendTransaction.calledOnce).to.equal(true)
+    const sent = sendTransaction.firstCall.args[0]
+    expect(sent.to).to.equal(contract)
+    expect(sent.data).to.equal(encodeBatchCalldata([call1, call2]))
+    expect(sent.value).to.equal(0n)
+  })
+
+  it('yields BatchTransactionData (no broadcast) when batching', async () => {
+    const { ctx, sendTransaction } = makeCtx()
+    ;(ctx as any).isBatching = true
+    const data = encodeFunctionData({ abi: ABI, functionName: 'setValue', args: [7n] })
+
+    const out = await drain(wrapTransaction('Batch', ctx, { contract, data }))
+
+    expect(sendTransaction.called).to.equal(false)
+    expect(out).to.have.length(1)
+    expect(out[0]).to.deep.include({ contract, data: [data] })
   })
 })

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -1,6 +1,7 @@
 import {
   AbiEvent,
   decodeEventLog,
+  encodeFunctionData,
   LocalAccount,
   Log,
   parseAbi,
@@ -33,7 +34,10 @@ class TransactionError extends Error {
 
 export class ChainMismatchError extends Error {
   override name = 'ChainMismatchError'
-  constructor(public expected: number, public actual: number) {
+  constructor(
+    public expected: number,
+    public actual: number
+  ) {
     super(
       `Wallet is connected to chainId=${actual} but transaction targets chainId=${expected}. ` +
         `Refusing to submit to avoid sending funds on the wrong network.`
@@ -60,6 +64,24 @@ export type BatchTransactionData = {
   data: HexString[]
   value?: bigint
   messages?: Record<number, MessageTypeWithSubType[]>
+}
+
+const MULTICALL_ABI = parseAbi(['function multicall(bytes[] data) payable'])
+
+/**
+ * Encode the outer calldata for a set of inner calls exactly as the signing
+ * path sends it: a single inner call is sent verbatim (no multicall wrapper),
+ * while two or more are wrapped in `multicall(bytes[])`. Centralizing this keeps
+ * `wrapTransaction` (broadcast) and `buildOnly` (build) byte-for-byte identical.
+ */
+export function encodeBatchCalldata(data: HexString[]): HexString {
+  if (data.length === 0) throw new Error('No calldata to encode')
+  if (data.length === 1) return data[0]!
+  return encodeFunctionData({
+    abi: MULTICALL_ABI,
+    functionName: 'multicall',
+    args: [data],
+  })
 }
 
 export async function* wrapTransaction(
@@ -109,18 +131,9 @@ export async function* wrapTransaction(
     if (!options.simulate) {
       const result = yield* doTransaction(title, ctx, async () => {
         await assertWalletChainMatches(ctx)
-        if (data.length === 1) {
-          return ctx.walletClient.sendTransaction({
-            to: contract,
-            data: data[0],
-            value,
-          })
-        }
-        return ctx.walletClient.writeContract({
-          address: contract,
-          abi: parseAbi(['function multicall(bytes[] data) payable']),
-          functionName: 'multicall',
-          args: [data],
+        return ctx.walletClient.sendTransaction({
+          to: contract,
+          data: encodeBatchCalldata(data),
           value,
         })
       })

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -4,7 +4,6 @@ import {
   encodeFunctionData,
   LocalAccount,
   Log,
-  parseAbi,
   RpcLog,
   toEventSelector,
   withRetry,
@@ -66,23 +65,21 @@ export type BatchTransactionData = {
   messages?: Record<number, MessageTypeWithSubType[]>
 }
 
-// Encoding-only ABI fragment for `encodeBatchCalldata` — not a contract-instance
-// ABI. The `multicall(bytes[])` signature is also present in several registered
-// contract ABIs (Hub, BalanceSheet, VaultRouter, …); this standalone fragment
-// keeps the encoder self-contained and independent of any one contract's ABI.
-const MULTICALL_ABI = parseAbi(['function multicall(bytes[] data) payable'])
-
 /**
  * Encode the outer calldata for a set of inner calls exactly as the signing
  * path sends it: a single inner call is sent verbatim (no multicall wrapper),
  * while two or more are wrapped in `multicall(bytes[])`. Centralizing this keeps
  * `wrapTransaction` (broadcast) and `buildOnly` (build) byte-for-byte identical.
+ *
+ * Uses the registered `ABI.Multicall` fragment — the `multicall(bytes[])`
+ * selector is identical across every protocol contract that supports batching,
+ * so the encoded bytes don't depend on which contract is targeted.
  */
 export function encodeBatchCalldata(data: HexString[]): HexString {
   if (data.length === 0) throw new Error('No calldata to encode')
   if (data.length === 1) return data[0]!
   return encodeFunctionData({
-    abi: MULTICALL_ABI,
+    abi: ABI.Multicall,
     functionName: 'multicall',
     args: [data],
   })
@@ -175,7 +172,7 @@ export async function* wrapTransaction(
           calls: [
             {
               to: contract,
-              abi: parseAbi(['function multicall(bytes[] data) payable']),
+              abi: ABI.Multicall,
               functionName: 'multicall',
               args: [data],
               value,

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -135,6 +135,14 @@ export async function* wrapTransaction(
     if (!options.simulate) {
       const result = yield* doTransaction(title, ctx, async () => {
         await assertWalletChainMatches(ctx)
+        // Both the single-call and multicall cases broadcast via `sendTransaction`
+        // with calldata from `encodeBatchCalldata` (the same encoder `buildOnly`
+        // uses), instead of `writeContract` for the multicall case. The bytes are
+        // identical — `writeContract` just calls `encodeFunctionData` + `sendTransaction`
+        // internally — so the on-chain effect and gas are unchanged; this only
+        // moves ABI encoding to one shared helper so the build and signing paths
+        // can never diverge. (Pre-flight ABI validation is unaffected: the calldata
+        // is encoded from the same ABI either way.)
         return ctx.walletClient.sendTransaction({
           to: contract,
           data: encodeBatchCalldata(data),

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -66,6 +66,10 @@ export type BatchTransactionData = {
   messages?: Record<number, MessageTypeWithSubType[]>
 }
 
+// Encoding-only ABI fragment for `encodeBatchCalldata` — not a contract-instance
+// ABI. The `multicall(bytes[])` signature is also present in several registered
+// contract ABIs (Hub, BalanceSheet, VaultRouter, …); this standalone fragment
+// keeps the encoder self-contained and independent of any one contract's ABI.
 const MULTICALL_ABI = parseAbi(['function multicall(bytes[] data) payable'])
 
 /**


### PR DESCRIPTION
## Build-Only Transaction API

Implements the build-only transaction API specified in
[`.claude/docs/BUILD_ONLY_API.md`](.claude/docs/BUILD_ONLY_API.md) (Phases 1–3).

`Centrifuge.buildOnly(tx, options?)` returns the **unsigned calldata** a
transaction method would send — no signer, no simulation, no broadcast. It runs
the full construction logic (encoding, merkle, weiroll, IPFS pinning, address
resolution), because that work *is* what produces the bytes, and stops at the
calldata.

### Why

Consumers that sign somewhere other than an in-process EOA/EIP-1193 wallet —
custodial/MPC signers (Fordefi, Fireblocks), Safe proposal flows, offline
signing, or a "review calldata before signing" UX — need only the unsigned
bytes; they own custody, policy, and broadcast. The driving case is the
`centrifuge/backend` `SdkTxBuilder`, which today either re-implements the SDK's
complex encoding natively or abuses `batchTransactions([oneTx])` as a de-facto
build call. `buildOnly` gives them a named, typed, documented entry point so the
SDK is the single source of truth for calldata.

### What changed

**Phase 1 — signer-optional build path (internal)**
- Added `isBuilding` to `TransactionContext`.
- Added a build-mode branch to `_transact`: when a tx is flagged for build-only,
  it skips signer/wallet-client creation, address resolution, chain switching,
  and broadcast — resolving only `chain`/`publicClient` — and runs through
  `wrapTransaction`'s existing batching branch, which yields unsigned calldata.
- `signingAddress` comes from `options.fromAddress` (defaults to the zero
  address) for methods whose construction reads the sender (e.g. permit flows).

**Phase 2 — public API**
- Added `Centrifuge.buildOnly(tx, options?): Promise<BuiltTransaction>`.
- Extracted `encodeBatchCalldata()` and routed **both** the signing path and
  `buildOnly` through it, so the two can never diverge on byte output (single
  call sent verbatim; 2+ wrapped in `multicall(bytes[])`).
- Added and exported `BuiltTransaction`, `BuiltCall`, `BuildOnlyOptions`.

**Phase 3 — tests + docs**
- 8 unit tests (no Tenderly): no-signer success, single-call & multicall
  byte-equality, zero-address default, `fromAddress` embedding, invalid-address
  error, cross-chain messages passthrough, and "signer untouched in build mode."
- Added a "Build-only / custodial signing" section to `SDK_USAGE.md` and marked
  the spec implemented.

### API

```typescript
interface BuiltCall {
  to: HexString
  data: HexString
  value: bigint
}
interface BuiltTransaction {
  centrifugeId: number
  chainId: number
  to: HexString          // target contract
  data: HexString        // calldata (multicall(bytes[]) when batched)
  value: bigint          // wei to send
  calls: BuiltCall[]     // decoded inner calls
  messages?: Record<number, MessageTypeWithSubType[]>  // cross-chain msgs, for fee estimation
}

// No setSigner() required.
const built = await centrifuge.buildOnly(pool.updateMetadata(metadata))
// hand built.data to a custodial signer (Fordefi, Safe, MPC) outside the SDK
