### PR TITLE
fix(crosschain): query createdAtTxHash, not removed preparedAtTxHash

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@centrifuge/sdk",
-  "version": "1.22.0",
+  "version": "1.22.1",
   "description": "",
   "homepage": "https://github.com/centrifuge/sdk/tree/main#readme",
   "author": "",

--- a/src/Centrifuge.test.ts
+++ b/src/Centrifuge.test.ts
@@ -237,7 +237,7 @@ describe('Centrifuge', () => {
         createdAt: '1773411360000',
         deliveredAt: null,
         completedAt: null,
-        preparedAtTxHash: '0xprepared',
+        createdAtTxHash: '0xprepared',
         deliveredAtTxHash: null,
         ...overrides,
       }
@@ -385,17 +385,17 @@ describe('Centrifuge', () => {
       expect(query).to.match(/adapterParticipations\(orderBy/)
     })
 
-    it('centrifuge.crosschainMessages encodes `preparedAtTxHash` filter and is not pool-scoped', async () => {
+    it('centrifuge.crosschainMessages encodes `createdAtTxHash` filter and is not pool-scoped', async () => {
       const centrifuge = new Centrifuge({ environment: 'testnet' })
       const queryIndexer = sinon.stub(centrifuge as any, '_queryIndexer').returns(
         of({ crosschainPayloads: { totalCount: 0, pageInfo: samplePageInfo, items: [] } })
       )
 
-      await centrifuge.crosschainMessages({ preparedAtTxHash: '0xbatchtx' })
+      await centrifuge.crosschainMessages({ createdAtTxHash: '0xbatchtx' })
 
       const [, vars] = queryIndexer.firstCall.args as [string, Record<string, unknown>]
       const filter = vars.filter as Record<string, unknown>
-      expect(filter).to.deep.equal({ preparedAtTxHash: '0xbatchtx' })
+      expect(filter).to.deep.equal({ createdAtTxHash: '0xbatchtx' })
       expect(filter.poolId).to.equal(undefined)
     })
 

--- a/src/entities/crosschainMessages.ts
+++ b/src/entities/crosschainMessages.ts
@@ -106,7 +106,7 @@ export type CrosschainMessage = {
   createdAt: Date
   deliveredAt: Date | undefined
   completedAt: Date | undefined
-  preparedAtTxHash: HexString | undefined
+  createdAtTxHash: HexString | undefined
   deliveredAtTxHash: HexString | undefined
   pool: CrosschainPoolRef | undefined
   token: CrosschainTokenRef | undefined
@@ -135,7 +135,7 @@ export type CrosschainMessagesFilter = {
   toCentrifugeId?: CentrifugeId
   status?: CrosschainMessageStatus | CrosschainMessageStatus[]
   /** Match all payloads emitted by the same source transaction (batch). */
-  preparedAtTxHash?: HexString
+  createdAtTxHash?: HexString
   limit?: number
   before?: string
   after?: string
@@ -201,7 +201,7 @@ const PAYLOAD_BASE_FIELDS = `
   createdAt
   deliveredAt
   completedAt
-  preparedAtTxHash
+  createdAtTxHash
   deliveredAtTxHash
 `
 
@@ -229,7 +229,7 @@ type CrosschainPayloadRaw = {
   createdAt: string
   deliveredAt: string | null
   completedAt: string | null
-  preparedAtTxHash: string | null
+  createdAtTxHash: string | null
   deliveredAtTxHash: string | null
   pool?: { id: string; name: string | null } | null
   token?: { name: string | null; symbol: string | null } | null
@@ -290,7 +290,7 @@ function toMessage(raw: CrosschainPayloadRaw): CrosschainMessage {
     createdAt: new Date(Number(raw.createdAt)),
     deliveredAt: raw.deliveredAt ? new Date(Number(raw.deliveredAt)) : undefined,
     completedAt: raw.completedAt ? new Date(Number(raw.completedAt)) : undefined,
-    preparedAtTxHash: raw.preparedAtTxHash ? (raw.preparedAtTxHash as HexString) : undefined,
+    createdAtTxHash: raw.createdAtTxHash ? (raw.createdAtTxHash as HexString) : undefined,
     deliveredAtTxHash: raw.deliveredAtTxHash ? (raw.deliveredAtTxHash as HexString) : undefined,
     pool: raw.pool ? { id: raw.pool.id, name: raw.pool.name ?? undefined } : undefined,
     token: raw.token ? { name: raw.token.name ?? undefined, symbol: raw.token.symbol ?? undefined } : undefined,
@@ -335,13 +335,13 @@ function toMessage(raw: CrosschainPayloadRaw): CrosschainMessage {
 }
 
 function buildWhere(filter: CrosschainMessagesFilter) {
-  const { poolId, fromCentrifugeId, toCentrifugeId, status, preparedAtTxHash } = filter
+  const { poolId, fromCentrifugeId, toCentrifugeId, status, createdAtTxHash } = filter
   return {
     ...(poolId !== undefined ? { poolId: (typeof poolId === 'bigint' ? poolId : poolId.raw).toString() } : {}),
     ...(fromCentrifugeId !== undefined ? { fromCentrifugeId: String(fromCentrifugeId) } : {}),
     ...(toCentrifugeId !== undefined ? { toCentrifugeId: String(toCentrifugeId) } : {}),
     ...(Array.isArray(status) ? { status_in: status } : status ? { status } : {}),
-    ...(preparedAtTxHash ? { preparedAtTxHash } : {}),
+    ...(createdAtTxHash ? { createdAtTxHash } : {}),
   }
 }
 
@@ -357,7 +357,7 @@ function filterCacheKey(filter: CrosschainMessagesFilter) {
     filter.fromCentrifugeId,
     filter.toCentrifugeId,
     Array.isArray(filter.status) ? filter.status.join(',') : (filter.status ?? ''),
-    filter.preparedAtTxHash ?? '',
+    filter.createdAtTxHash ?? '',
     filter.limit ?? '',
     filter.before ?? '',
     filter.after ?? '',


### PR DESCRIPTION
## Problem

`pool.crosschainMessages()` / `centrifuge.crosschainMessages()` query the indexer's **`crosschainPayloads`** entity, selecting and filtering on **`preparedAtTxHash`**. That field no longer exists on `CrosschainPayload`. The current schema exposes per-lifecycle hashes instead — `createdAtTxHash`, `sentAtTxHash`, `deliveredAtTxHash`, `completedAtTxHash`, `underpaidAtTxHash`, `partiallyFailedAtTxHash`.

Because `preparedAtTxHash` is in the field selection, the **entire query fails** GraphQL validation:

```
Cannot query field "preparedAtTxHash" on type "CrosschainPayload".
Did you mean "createdAtTxHash", "completedAtTxHash", "deliveredAtTxHash", "underpaidAtTxHash", or "sentAtTxHash"?
```

So every cross-chain-messages query errors out and returns nothing. Downstream, the management app's cross-chain transactions indicator is permanently empty even when a pool has in-flight payloads.

## Fix

Rename `preparedAtTxHash` → `createdAtTxHash` across the entity: the GraphQL selection, the raw payload type, `buildWhere`, the cache key, the mapping in `toMessage`, and the public `CrosschainMessage` / `CrosschainMessagesFilter` fields. The timestamp the query already reads is `createdAt`, so the hash now pairs with it consistently.

> Note: this renames a public field on `CrosschainMessage` and `CrosschainMessagesFilter`. It's effectively unusable today (the query 500s), so there's no working behavior to preserve, but flagging it as an API-surface change.

## Verification

Against `api.centrifuge.io`:
- The old selection (with `preparedAtTxHash`) → GraphQL validation error.
- The renamed selection (`createdAtTxHash`) → succeeds.
- `createdAtTxHash` carries the origin/source transaction hash (equals `sentAtTxHash` for sampled payloads).
- Live `CrosschainPayloadStatus` enum is `Underpaid | InTransit | Delivered | PartiallyFailed | Completed` — already matches the hand-written `CrosschainMessageStatus` type, so no status change needed.

`pnpm build` (tsc) passes; the 5 `crosschainMessages` unit tests pass (updated the fixture + the `createdAtTxHash` filter assertion).
