### PR TITLE
fix: point testnet pinning 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@centrifuge/sdk",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "description": "",
   "homepage": "https://github.com/centrifuge/sdk/tree/main#readme",
   "author": "",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@centrifuge/sdk",
-  "version": "1.15.2",
+  "version": "1.15.3",
   "description": "",
   "homepage": "https://github.com/centrifuge/sdk/tree/main#readme",
   "author": "",

--- a/src/Centrifuge.ts
+++ b/src/Centrifuge.ts
@@ -83,7 +83,7 @@ import {
 } from './utils/transaction.js'
 import { AssetId, CentrifugeId, PoolId, ShareClassId } from './utils/types.js'
 
-const PINNING_API_DEMO = 'https://europe-central2-peak-vista-185616.cloudfunctions.net/pinning-api-demo'
+const PINNING_API = 'https://pinning.centrifugelabs.io'
 
 // Update when centrifuge/workflows cuts a new release.
 // CIDs are in the GitHub release notes: https://github.com/centrifuge/workflows/releases
@@ -112,12 +112,12 @@ const envConfig = {
   mainnet: {
     indexerUrl: 'https://api.centrifuge.io',
     ipfsUrl: 'https://ipfs.centrifuge.io',
-    ...createPinning(PINNING_API_DEMO),
+    ...createPinning(PINNING_API),
   },
   testnet: {
     indexerUrl: 'https://api-v3-test.cfg.embrio.tech/graphql',
     ipfsUrl: 'https://ipfs.centrifuge.io',
-    ...createPinning(PINNING_API_DEMO),
+    ...createPinning(PINNING_API),
   },
 } satisfies Record<string, EnvConfig>
 


### PR DESCRIPTION
The SDK hardcoded a single Google Cloud Function pinning endpoint for both mainnet and testnet. That function is no longer reachable, instead we are using the new endpoint.