### PR TITLE
fix(verifyDeployments): drop mismatched address instead of rejecting the whole response

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@centrifuge/sdk",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "description": "",
   "homepage": "https://github.com/centrifuge/sdk/tree/main#readme",
   "author": "",

--- a/src/Centrifuge.ts
+++ b/src/Centrifuge.ts
@@ -1461,10 +1461,12 @@ export class Centrifuge {
 
   /**
    * Verified-deployments stream. On mainnet, every emission has been checked against
-   * the bundled `KNOWN_DEPLOYMENTS` allowlist; a mismatch surfaces as a
-   * `DeploymentMismatchError` on the observable. Apps can subscribe to this directly
-   * to render a maintenance/error UI when the indexer disagrees with the SDK's
-   * bundled addresses. Protects against indexer misconfiguration or compromise.
+   * the bundled `KNOWN_DEPLOYMENTS` allowlist. A contract whose indexer-returned address
+   * doesn't match is dropped from the emission (with a warning) so it can't be used,
+   * rather than failing the whole stream — one stale address never takes down every
+   * chain. An unknown centrifugeId still surfaces as `UnknownDeploymentError`. Protects
+   * against indexer misconfiguration or compromise: an unverified address is never
+   * returned, so the app can't transact against it.
    */
   deployments() {
     return this._deployments()

--- a/src/config/verifyDeployments.test.ts
+++ b/src/config/verifyDeployments.test.ts
@@ -1,10 +1,6 @@
 import { expect } from 'chai'
-import {
-  DeploymentMismatchError,
-  UnknownDeploymentError,
-  verifyDeployments,
-  type IndexerDeploymentResponse,
-} from './verifyDeployments.js'
+import sinon from 'sinon'
+import { UnknownDeploymentError, verifyDeployments, type IndexerDeploymentResponse } from './verifyDeployments.js'
 import type { KnownDeployment } from './deployments.js'
 import type { HexString } from '../types/index.js'
 
@@ -113,7 +109,9 @@ function makeAllowlistEntry(overrides: Partial<KnownDeployment> = {}): KnownDepl
   }
 }
 
-function makeResponse(deployments: ReturnType<typeof makeDeployment>[] = [makeDeployment()]): IndexerDeploymentResponse {
+function makeResponse(
+  deployments: ReturnType<typeof makeDeployment>[] = [makeDeployment()]
+): IndexerDeploymentResponse {
   return {
     blockchains: { items: [{ id: '11155111', centrifugeId: '1', name: 'sepolia' }] },
     deployments: { items: deployments },
@@ -134,27 +132,38 @@ describe('verifyDeployments', () => {
     expect(() => verifyDeployments(data, allowlist)).not.to.throw()
   })
 
-  it('throws DeploymentMismatchError when an indexer address differs from the allowlist', () => {
-    const allowlist = { 1: makeAllowlistEntry() }
-    const data = makeResponse([makeDeployment({ hub: ADDR_EVIL })])
-    expect(() => verifyDeployments(data, allowlist))
-      .to.throw(DeploymentMismatchError)
-      .with.property('field', 'hub')
+  it('drops a mismatched address (and warns) instead of rejecting the whole response', () => {
+    const warn = sinon.stub(console, 'warn')
+    try {
+      const allowlist = { 1: makeAllowlistEntry() }
+      const data = makeResponse([makeDeployment({ hub: ADDR_EVIL })])
+      const result = verifyDeployments(data, allowlist)
+      const item = result.deployments.items[0] as Record<string, unknown>
+      // Mismatched field is removed so it can never be used...
+      expect(item.hub).to.equal(undefined)
+      // ...but every other field on the deployment is untouched.
+      expect(item.spoke).to.equal(ADDR_A)
+      expect(warn.calledOnce).to.equal(true)
+      expect(warn.firstCall.args[0]).to.contain("field='hub'")
+    } finally {
+      warn.restore()
+    }
   })
 
-  it('reports the offending centrifugeId and field in the error', () => {
-    const allowlist = { 1: makeAllowlistEntry() }
-    const data = makeResponse([makeDeployment({ spoke: ADDR_EVIL })])
+  it('only drops the offending field, leaving other deployments intact', () => {
+    const warn = sinon.stub(console, 'warn')
     try {
-      verifyDeployments(data, allowlist)
-      expect.fail('expected throw')
-    } catch (err) {
-      expect(err).to.be.instanceOf(DeploymentMismatchError)
-      const e = err as DeploymentMismatchError
-      expect(e.centrifugeId).to.equal(1)
-      expect(e.field).to.equal('spoke')
-      expect(e.actual).to.equal(ADDR_EVIL)
-      expect(e.expected.toLowerCase()).to.equal(ADDR_A.toLowerCase())
+      const allowlist = { 1: makeAllowlistEntry(), 2: makeAllowlistEntry({ name: 'other', chainId: 2 }) }
+      const good = makeDeployment({ centrifugeId: '2' })
+      const bad = makeDeployment({ centrifugeId: '1', spoke: ADDR_EVIL })
+      const result = verifyDeployments(makeResponse([good, bad]), allowlist)
+      const goodItem = result.deployments.items[0] as Record<string, unknown>
+      const badItem = result.deployments.items[1] as Record<string, unknown>
+      expect(goodItem.spoke).to.equal(ADDR_A) // untouched chain unaffected
+      expect(badItem.spoke).to.equal(undefined) // only the mismatched field dropped
+      expect(badItem.hub).to.equal(ADDR_A)
+    } finally {
+      warn.restore()
     }
   })
 
@@ -170,20 +179,25 @@ describe('verifyDeployments', () => {
     expect(() => verifyDeployments(data, allowlist, { allowUnknownDeployments: true })).not.to.throw()
   })
 
-  it('still rejects mismatches on known centIds even when allowUnknownDeployments=true', () => {
-    const allowlist = { 1: makeAllowlistEntry() }
-    const data = makeResponse([makeDeployment({ hub: ADDR_EVIL })])
-    expect(() => verifyDeployments(data, allowlist, { allowUnknownDeployments: true })).to.throw(
-      DeploymentMismatchError
-    )
+  it('still drops mismatches on known centIds even when allowUnknownDeployments=true', () => {
+    const warn = sinon.stub(console, 'warn')
+    try {
+      const allowlist = { 1: makeAllowlistEntry() }
+      const data = makeResponse([makeDeployment({ hub: ADDR_EVIL })])
+      const result = verifyDeployments(data, allowlist, { allowUnknownDeployments: true })
+      expect((result.deployments.items[0] as Record<string, unknown>).hub).to.equal(undefined)
+      expect(warn.calledOnce).to.equal(true)
+    } finally {
+      warn.restore()
+    }
   })
 
   it('skips fields the indexer omits (allowlist is a superset of the SDK query)', () => {
     // The bundled allowlist is generated from the protocol repo and contains
     // every deployed contract; the SDK's GraphQL query is a subset. Fields
     // absent from the indexer response are skipped — the verifier only checks
-    // what came back. A substituted address is still caught (covered by
-    // 'throws DeploymentMismatchError when an indexer address differs' above).
+    // what came back. A substituted address that IS returned is still handled
+    // (covered by 'drops a mismatched address' above).
     const allowlist = { 1: makeAllowlistEntry() }
     const partial = makeDeployment()
     delete (partial as Record<string, unknown>).hub

--- a/src/config/verifyDeployments.ts
+++ b/src/config/verifyDeployments.ts
@@ -54,8 +54,20 @@ export type VerifyOptions = {
  * Verifies an indexer deployment response against the bundled KNOWN_DEPLOYMENTS allowlist.
  *
  * For each indexer-returned deployment, looks up the expected record by centrifugeId
- * and asserts every contract address field matches (case-insensitive). Throws on the
- * first mismatch. Returns the response unchanged on success.
+ * and checks every contract address field (case-insensitive).
+ *
+ * On a mismatch the offending **field is dropped** from the returned deployment (with a
+ * warning) rather than throwing — so one bad address never rejects the whole response.
+ * The indexer can transiently serve a stale (older, still-real) address while reindexing
+ * after a redeploy; that must not lock the entire app across every chain. Dropping the
+ * field keeps the security guarantee — the SDK never hands back an unverified address, so
+ * the app can never transact against one — while the rest of that chain, and every other
+ * chain, keeps working. The dropped contract is simply unavailable until the indexer
+ * matches the bundled allowlist. The response is mutated in place and returned.
+ *
+ * An unknown centrifugeId still throws `UnknownDeploymentError` in strict mode (the
+ * default): a fake chain added to a compromised indexer is a different threat from a
+ * stale-but-real contract address, and there's nothing safe to fall back to.
  *
  * If the bundled allowlist is empty (e.g. on first commit before `pnpm gen:deployments`
  * has been run), verification is skipped with a warning. This avoids breaking dev/test
@@ -98,11 +110,18 @@ export function verifyDeployments(
       // the protocol repo and includes every deployed contract; the SDK's
       // GraphQL query is a subset of that. We only validate what was actually
       // returned — if the SDK doesn't query a field, it can't verify it, but
-      // it also doesn't depend on it. An attacker substituting a poisoned
-      // address for a queried field is still caught.
+      // it also doesn't depend on it.
       if (!actualValue) continue
       if (!addressesEqual(actualValue, expectedValue as string)) {
-        throw new DeploymentMismatchError(centId, String(field), String(expectedValue), actualValue)
+        // Drop the unverified field instead of rejecting the whole response.
+        // The app never receives the address, so it can't transact against it;
+        // only this one contract becomes unavailable. See the function doc.
+        console.warn(
+          `[centrifuge-sdk] Dropping unverified address for centrifugeId=${centId} field='${String(field)}'. ` +
+            `Expected ${String(expectedValue)}, indexer returned ${actualValue}. This contract will be ` +
+            `unavailable until the indexer matches the bundled allowlist.`
+        )
+        delete (deployment as Record<string, unknown>)[field as string]
       }
     }
   }


### PR DESCRIPTION
## Problem

`verifyDeployments` threw `DeploymentMismatchError` on the **first** contract-address mismatch, which rejected the **entire** indexer deployment response — for every chain. Since `_deployments()` feeds `protocolAddresses` / `idToChain` / `chainToId`, a single stale address took the whole SDK (and the app on top of it) down.

This bit us in production: while the indexer reindexes after a redeploy it briefly serves a **previous, still-real** address (e.g. an old `wormholeAdapter` on Avalanche), which tripped the app's full-screen *"Service unavailable — do not transact"* gate even though nothing was actually compromised.

## Fix

On a mismatch, **drop just that field** from the returned deployment (with a `console.warn`) and continue, instead of throwing.

- **Security guarantee is unchanged:** the SDK never hands back an unverified address, so the app can never transact against one. The mismatched contract is simply *unavailable* until the indexer matches the bundled allowlist.
- **Blast radius is now one contract**, not the whole app — other contracts on that chain, and every other chain, keep working.
- **Unknown `centrifugeId`s still throw** `UnknownDeploymentError` in strict mode — a fake chain on a compromised indexer is a different threat with nothing safe to fall back to.

`DeploymentMismatchError` remains exported (public API) but is no longer thrown by `verifyDeployments`.

## Tests

Updated the mismatch tests to assert the field is dropped + warned (not thrown), added an isolation test (one bad deployment doesn't affect others), and kept the unknown-centId / non-numeric / empty-allowlist / optional-field cases. All 11 pass; `tsc` clean.

## Why here and not the app

This replaces a closed app-side mitigation (centrifuge/apps-management#1118) — suppressing the UI gate there didn't stop the SDK from rejecting the response, so the app stayed degraded. The verification strategy is the right layer to fix.

