### PR TITLE
feat(poolMetadata)!: fold off-chain holdings into a table + right-column groups/icons/availableNetworks (1.17.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@centrifuge/sdk",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "",
   "homepage": "https://github.com/centrifuge/sdk/tree/main#readme",
   "author": "",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@centrifuge/sdk",
-  "version": "1.17.0",
+  "version": "1.16.0",
   "description": "",
   "homepage": "https://github.com/centrifuge/sdk/tree/main#readme",
   "author": "",

--- a/src/entities/Pool.ts
+++ b/src/entities/Pool.ts
@@ -740,7 +740,6 @@ export class Pool extends Entity {
                   poolRatings: [],
                 },
                 shareClasses: {},
-                holdings: { headers: [], data: [] },
               }
 
         const newShareClassesById: PoolMetadata['shareClasses'] = {}
@@ -792,12 +791,6 @@ export class Pool extends Entity {
             factsheet: metadataInput?.factsheet ?? baseMetadata.pool.factsheet,
           },
           shareClasses: { ...baseMetadata.shareClasses, ...newShareClassesById },
-          holdings: {
-            headers: Array.from(
-              new Set([...(baseMetadata.holdings?.headers ?? []), ...(metadataInput?.holdings?.headers ?? [])])
-            ),
-            data: metadataInput?.holdings?.data ?? baseMetadata.holdings?.data ?? [],
-          },
         }
 
         updatedShareClasses.forEach((sc) => {

--- a/src/tests/mocks/mockPoolMetadataV2.ts
+++ b/src/tests/mocks/mockPoolMetadataV2.ts
@@ -133,7 +133,19 @@ export const mockPoolMetadataV2: PoolMetadataV2 = {
         },
         { type: 'section', id: 'performance', ref: 'onchainMetrics' },
       ],
-      sections: [{ type: 'section', id: 'contracts', ref: 'smartContracts', visibility: 'public' }],
+      sections: [
+        {
+          type: 'table',
+          id: 'holdings',
+          title: 'Holdings',
+          headers: ['Asset', 'ISIN', 'Amount'],
+          rows: [
+            ['T-Bill 2026', 'US912796RW0', 1_000_000],
+            ['T-Bill 2027', '', 2_500_000],
+          ],
+        },
+        { type: 'section', id: 'contracts', ref: 'smartContracts', visibility: 'public' },
+      ],
     },
   },
   shareClasses: {

--- a/src/tests/mocks/mockPoolMetadataV2.ts
+++ b/src/tests/mocks/mockPoolMetadataV2.ts
@@ -47,10 +47,34 @@ export const mockPoolMetadataV2: PoolMetadataV2 = {
     poolRatings: [{ agency: 'Fake Agency', value: 'AAA', reportUrl: 'https://example.com/rating' }],
     factsheet: {
       keyFacts: [
-        { label: 'Issuer', value: 'Fake Issuer' },
-        { label: 'Asset type', value: 'Private credit - Fake Subclass' },
-        { label: 'APY', valueRef: 'apy', tooltip: 'Net of fees' },
-        { label: 'Secret fact', value: 'hidden value', visibility: 'whitelisted' },
+        {
+          type: 'keyFactGroup',
+          id: 'overview-facts',
+          title: 'Overview',
+          items: [
+            { label: 'Issuer', value: { kind: 'text', text: 'Fake Issuer' } },
+            { label: 'Asset type', value: { kind: 'text', text: 'Private credit - Fake Subclass' } },
+            { label: 'APY', value: { kind: 'ref', ref: 'apy' }, tooltip: 'Net of fees' },
+            { label: 'Networks', value: { kind: 'ref', ref: 'availableNetworks' } },
+          ],
+        },
+        {
+          type: 'keyFactGroup',
+          id: 'trust-facts',
+          items: [
+            {
+              label: 'Custody',
+              value: {
+                kind: 'icons',
+                icons: [
+                  { source: 'app', key: 'fordefi', label: 'Fordefi' },
+                  { source: 'metadata', file: { uri: 'ipfs://QmRatingIcon', mime: 'image/svg+xml' }, alt: 'Moody’s' },
+                ],
+              },
+            },
+            { label: 'Secret fact', value: { kind: 'text', text: 'hidden value' }, visibility: 'whitelisted' },
+          ],
+        },
       ],
       body: [
         { type: 'text', id: 'overview', title: 'Overview', body: 'Fake **overview** with a [link](https://x.io).' },
@@ -71,15 +95,18 @@ export const mockPoolMetadataV2: PoolMetadataV2 = {
           id: 'inline-chart',
           title: 'Allocation',
           chartType: 'donut',
-          series: [
-            {
-              name: 'Allocation',
-              data: [
-                { label: 'Cash', value: 40 },
-                { label: 'Loans', value: 60 },
-              ],
-            },
-          ],
+          data: {
+            kind: 'inline',
+            series: [
+              {
+                name: 'Allocation',
+                data: [
+                  { label: 'Cash', value: 40 },
+                  { label: 'Loans', value: 60 },
+                ],
+              },
+            ],
+          },
           legend: true,
         },
         {
@@ -87,7 +114,7 @@ export const mockPoolMetadataV2: PoolMetadataV2 = {
           id: 'live-chart',
           title: 'APY vs benchmarks',
           chartType: 'line',
-          dataRef: 'apyVsBenchmarks',
+          data: { kind: 'ref', dataRef: 'apyVsBenchmarks' },
           xAxis: { label: 'Date', type: 'time' },
           yAxis: { label: 'APY', format: 'percent' },
         },

--- a/src/tests/mocks/mockPoolMetadataV2.ts
+++ b/src/tests/mocks/mockPoolMetadataV2.ts
@@ -44,7 +44,14 @@ export const mockPoolMetadataV2: PoolMetadataV2 = {
     ],
     investorType: 'Fake Investor Type',
     poolStructure: 'Fake Structure',
-    poolRatings: [{ agency: 'Fake Agency', value: 'AAA', reportUrl: 'https://example.com/rating' }],
+    poolRatings: [
+      {
+        agency: 'Fake Agency',
+        value: 'AAA',
+        reportUrl: 'https://example.com/rating',
+        reportFile: { uri: 'ipfs://QmRatingReport', mime: 'application/pdf' },
+      },
+    ],
     factsheet: {
       keyFacts: [
         {
@@ -56,6 +63,7 @@ export const mockPoolMetadataV2: PoolMetadataV2 = {
             { label: 'Asset type', value: { kind: 'text', text: 'Private credit - Fake Subclass' } },
             { label: 'APY', value: { kind: 'ref', ref: 'apy' }, tooltip: 'Net of fees' },
             { label: 'Networks', value: { kind: 'ref', ref: 'availableNetworks' } },
+            { label: 'Ratings', value: { kind: 'ref', ref: 'ratings' } },
           ],
         },
         {

--- a/src/types/poolInput.ts
+++ b/src/types/poolInput.ts
@@ -67,9 +67,5 @@ export type PoolMetadataInput = {
   underlying?: {
     poolId?: number
   }
-  holdings?: {
-    headers: string[]
-    data: Record<string, unknown>[]
-  }
   listed?: boolean
 }

--- a/src/types/poolMetadata.ts
+++ b/src/types/poolMetadata.ts
@@ -243,6 +243,16 @@ export type PoolMetadataV1 = {
   }
   addressLabels?: Record<string, string>
   workflowPolicies?: WorkflowPolicy[]
+  /** Per-share-class withdraw addresses, keyed by share class id. Engine config, carried verbatim. */
+  withdrawManagers?: Record<HexString, WithdrawManager[]>
+}
+
+/** A configured withdraw destination for a share class on a given chain/asset. */
+export type WithdrawManager = {
+  assetAddress: HexString
+  chainId: string
+  manager: HexString
+  label?: string
 }
 
 /* ------------------------------------------------------------------------------------------------
@@ -491,7 +501,8 @@ export type PoolRatingV2 = {
  * extras) and folds the legacy display fields (`details`, `issuer.description/categories`) and the
  * off-chain `holdings` blob (into a `table` section) into `pool.factsheet`. `poolRatings` stays a
  * typed field (surfaced via the `ratings` key-fact ref). Engine fields (`shareClasses`,
- * `merkleProofManager`, `addressLabels`, `workflowPolicies`) are preserved verbatim.
+ * `merkleProofManager`, `addressLabels`, `workflowPolicies`, `withdrawManagers`) are preserved
+ * verbatim.
  */
 export type PoolMetadataV2 = {
   version: 2
@@ -508,6 +519,7 @@ export type PoolMetadataV2 = {
   }
   addressLabels?: PoolMetadataV1['addressLabels']
   workflowPolicies?: PoolMetadataV1['workflowPolicies']
+  withdrawManagers?: PoolMetadataV1['withdrawManagers']
 }
 
 /**

--- a/src/types/poolMetadata.ts
+++ b/src/types/poolMetadata.ts
@@ -319,16 +319,49 @@ export type ChartSeries = {
 }
 
 /**
- * A right-column key fact. `value` is static text; `valueRef: 'apy'` instead resolves live from
- * `shareClasses[scId].apy` (+ `apyTooltip`). The `valueRef` set is closed and grows additively.
+ * An icon, optionally with a label (renders as an icon, or an icon+text pill when `label` is set).
+ * - `source: 'metadata'` carries the image inline (issuer-supplied).
+ * - `source: 'app'` references an app-owned icon by `key` (e.g. `'fordefi'`, `'moodys'`). The icon
+ *   `key` registry is app-owned; it is not yet enumerated, so the SDK validates it as a string only.
  */
+export type IconRef =
+  | { source: 'metadata'; file: FileType; alt?: string; label?: string }
+  | { source: 'app'; key: string; label?: string }
+
+/**
+ * A key fact's value, discriminated by `kind` so there is no value/valueRef/icons precedence
+ * ambiguity. Exactly one kind applies:
+ * - `text`  — static text.
+ * - `icons` — author-chosen icons (each may carry a label).
+ * - `ref`   — app-owned LIVE data + rendering. The `ref` set is closed and SDK-validated on write
+ *             (extended via a coordinated SDK release, see {@link DataRef}). `'apy'` renders
+ *             formatted APY (via the app's `usePoolApy`); `'availableNetworks'` renders the token's
+ *             deployed chains with the app's built-in network icons (it does NOT produce `IconRef[]`).
+ */
+export type KeyFactValue =
+  | { kind: 'text'; text: string }
+  | { kind: 'icons'; icons: IconRef[] }
+  | { kind: 'ref'; ref: 'apy' | 'availableNetworks' }
+
+/** A right-column key fact. Its value is a single discriminated {@link KeyFactValue}. */
 export type KeyFact = {
   label: string
-  value?: string
-  valueRef?: 'apy'
+  value: KeyFactValue
   tooltip?: string
   href?: string
   visibility?: Visibility
+}
+
+/**
+ * A titled right-column group of key facts. Every key fact lives inside a group; there are no
+ * top-level bare key facts. An untitled group renders as ungrouped rows.
+ */
+export type KeyFactGroup = {
+  type: 'keyFactGroup'
+  id: string
+  title?: string
+  visibility?: Visibility
+  items: KeyFact[]
 }
 
 type BlockBase = { id: string; title?: string; visibility?: Visibility }
@@ -345,13 +378,17 @@ export type TableBlock = BlockBase & {
   asOf?: string
 }
 
+/**
+ * A chart's data source, discriminated by `kind` (no inline-vs-live ambiguity):
+ * - `inline` — metadata-supplied series.
+ * - `ref`    — an app/indexer-computed dataset, referenced by a closed, SDK-validated {@link DataRef}.
+ */
+export type ChartData = { kind: 'inline'; series: ChartSeries[] } | { kind: 'ref'; dataRef: DataRef }
+
 export type ChartBlock = BlockBase & {
   type: 'chart'
   chartType: ChartType
-  /** Inline metadata-supplied data ... */
-  series?: ChartSeries[]
-  /** ... or an app/indexer-computed dataset (mutually exclusive with `series`). */
-  dataRef?: DataRef
+  data: ChartData
   stacked?: boolean
   legend?: boolean
   xAxis?: { label?: string; type?: 'category' | 'time' | 'number' }
@@ -427,8 +464,8 @@ export type LayoutItem = ContentBlock | SectionRefBlock
 export type Factsheet = {
   /** Top region, left column, ordered (authored blocks + app section refs e.g. `onchainMetrics`). */
   body: LayoutItem[]
-  /** Top region, right column, ordered. */
-  keyFacts: KeyFact[]
+  /** Top region, right column, ordered groups of key facts (groups only, no bare key facts). */
+  keyFacts: KeyFactGroup[]
   /** Full-width region below, ordered. Omit to let the app render its default sections. */
   sections?: LayoutItem[]
 }

--- a/src/types/poolMetadata.ts
+++ b/src/types/poolMetadata.ts
@@ -333,15 +333,18 @@ export type IconRef =
  * ambiguity. Exactly one kind applies:
  * - `text`  — static text.
  * - `icons` — author-chosen icons (each may carry a label).
- * - `ref`   — app-owned LIVE data + rendering. The `ref` set is closed and SDK-validated on write
- *             (extended via a coordinated SDK release, see {@link DataRef}). `'apy'` renders
- *             formatted APY (via the app's `usePoolApy`); `'availableNetworks'` renders the token's
- *             deployed chains with the app's built-in network icons (it does NOT produce `IconRef[]`).
+ * - `ref`   — app-owned widget that reads existing data (an indexer query or a typed metadata
+ *             field) and renders it. The `ref` set is closed and SDK-validated on write (extended
+ *             via a coordinated SDK release, see {@link DataRef}). `'apy'` renders formatted APY
+ *             (via the app's `usePoolApy`); `'availableNetworks'` renders the token's deployed
+ *             chains with the app's built-in network icons; `'ratings'` renders the typed
+ *             `pool.poolRatings` field as icon+text pills with per-rating links (`agency` → icon,
+ *             `value` → label, `reportUrl`/`reportFile` → link). None of these produce `IconRef[]`.
  */
 export type KeyFactValue =
   | { kind: 'text'; text: string }
   | { kind: 'icons'; icons: IconRef[] }
-  | { kind: 'ref'; ref: 'apy' | 'availableNetworks' }
+  | { kind: 'ref'; ref: 'apy' | 'availableNetworks' | 'ratings' }
 
 /** A right-column key fact. Its value is a single discriminated {@link KeyFactValue}. */
 export type KeyFact = {
@@ -470,20 +473,25 @@ export type Factsheet = {
   sections?: LayoutItem[]
 }
 
-/** A pool rating without the unused `reportFile` PDF (migrated into a Documents block in v2). */
+/**
+ * A pool rating, kept as a typed field in v2 (the single source of truth for ratings). The
+ * `ratings` {@link KeyFactValue} `ref` widget renders this verbatim: `agency` → icon, `value` →
+ * label, `reportUrl`/`reportFile` → the per-rating link.
+ */
 export type PoolRatingV2 = {
   agency?: string
   value?: string
   reportUrl?: string
+  reportFile?: FileType | null
 }
 
 /**
  * Versioned, factsheet-aware pool metadata. Drops fields unused by every consumer
  * (`newInvestmentsStatus`, `loanTemplates`, `reports`, `issuer.repName/shortDescription`, onboarding
- * extras) and folds the legacy display fields (`details`, `issuer.description/categories`,
- * `poolRatings[].reportFile`) and the off-chain `holdings` blob (into a `table` section) into
- * `pool.factsheet`. Engine fields (`shareClasses`, `merkleProofManager`, `addressLabels`,
- * `workflowPolicies`) are preserved verbatim.
+ * extras) and folds the legacy display fields (`details`, `issuer.description/categories`) and the
+ * off-chain `holdings` blob (into a `table` section) into `pool.factsheet`. `poolRatings` stays a
+ * typed field (surfaced via the `ratings` key-fact ref). Engine fields (`shareClasses`,
+ * `merkleProofManager`, `addressLabels`, `workflowPolicies`) are preserved verbatim.
  */
 export type PoolMetadataV2 = {
   version: 2

--- a/src/types/poolMetadata.ts
+++ b/src/types/poolMetadata.ts
@@ -444,8 +444,9 @@ export type PoolRatingV2 = {
  * Versioned, factsheet-aware pool metadata. Drops fields unused by every consumer
  * (`newInvestmentsStatus`, `loanTemplates`, `reports`, `issuer.repName/shortDescription`, onboarding
  * extras) and folds the legacy display fields (`details`, `issuer.description/categories`,
- * `poolRatings[].reportFile`) into `pool.factsheet`. Engine fields (`shareClasses`,
- * `merkleProofManager`, `holdings`, `addressLabels`, `workflowPolicies`) are preserved verbatim.
+ * `poolRatings[].reportFile`) and the off-chain `holdings` blob (into a `table` section) into
+ * `pool.factsheet`. Engine fields (`shareClasses`, `merkleProofManager`, `addressLabels`,
+ * `workflowPolicies`) are preserved verbatim.
  */
 export type PoolMetadataV2 = {
   version: 2
@@ -460,15 +461,15 @@ export type PoolMetadataV2 = {
     kycRestrictedCountries?: string[]
     kybRestrictedCountries?: string[]
   }
-  holdings?: PoolMetadataV1['holdings']
   addressLabels?: PoolMetadataV1['addressLabels']
   workflowPolicies?: PoolMetadataV1['workflowPolicies']
 }
 
 /**
  * Public alias usable for either shape. Reads of common fields (`pool.name`, `shareClasses`,
- * `addressLabels`, `onboarding`, `holdings`, …) are valid without narrowing; discriminate on
- * `version` (or use {@link isPoolMetadataV2}) before touching v2-only fields like `pool.factsheet`.
+ * `addressLabels`, `onboarding`, …) are valid without narrowing; discriminate on `version` (or use
+ * {@link isPoolMetadataV2}) before touching v2-only fields like `pool.factsheet`. Note `holdings`
+ * exists only on {@link PoolMetadataV1}; in v2 it lives in `pool.factsheet` as a `table` section.
  */
 export type PoolMetadata = PoolMetadataV1 | PoolMetadataV2
 

--- a/src/utils/poolMetadataMigration.test.ts
+++ b/src/utils/poolMetadataMigration.test.ts
@@ -107,20 +107,26 @@ describe('migratePoolMetadataToV2', () => {
     expect(v2.workflowPolicies).to.deep.equal([])
   })
 
-  it('strips reportFile from kept poolRatings', () => {
+  it('preserves poolRatings verbatim as a typed field (incl. reportFile)', () => {
     const v2 = migratePoolMetadataToV2(legacyFixture())
     expect(v2.pool.poolRatings).to.deep.equal([
-      { agency: 'Moodys', value: 'Aaa', reportUrl: 'https://x.io/r1' },
+      {
+        agency: 'Moodys',
+        value: 'Aaa',
+        reportUrl: 'https://x.io/r1',
+        reportFile: { uri: 'ipfs://Qm1', mime: 'application/pdf' },
+      },
       { agency: 'S&P', value: 'AAA' },
     ])
   })
 
-  it('projects key facts into one untitled group with discriminated values, in order', () => {
+  it('projects a titled "Key facts" group and splits service-provider categories into "Service providers"', () => {
     const { keyFacts } = migratePoolMetadataToV2(legacyFixture()).pool.factsheet!
     expect(keyFacts).to.deep.equal([
       {
         type: 'keyFactGroup',
         id: 'key-facts',
+        title: 'Key facts',
         items: [
           { label: 'Issuer', value: { kind: 'text', text: 'Acme Issuer' } },
           { label: 'Asset type', value: { kind: 'text', text: 'Public credit - T-Bills' } },
@@ -129,10 +135,38 @@ describe('migratePoolMetadataToV2', () => {
           { label: 'Average asset maturity', value: { kind: 'text', text: '63 days' } },
           { label: 'Expense ratio', value: { kind: 'text', text: '0.25%' } },
           { label: 'Min. investment', value: { kind: 'text', text: '2,500' } },
+          { label: 'Ratings', value: { kind: 'ref', ref: 'ratings' } },
+        ],
+      },
+      {
+        type: 'keyFactGroup',
+        id: 'service-providers',
+        title: 'Service providers',
+        // 'Trustee' and 'Auditor' are known service-provider category types.
+        items: [
           { label: 'Trustee', value: { kind: 'text', text: 'Acme Trust' } },
           { label: 'Auditor', value: { kind: 'text', text: 'Acme Audit' } },
         ],
       },
+    ])
+  })
+
+  it('keeps unknown categories in "Key facts" and omits the Service providers group when none match', () => {
+    const legacy = legacyFixture()
+    legacy.pool.issuer.categories = [{ type: 'Historical default rate', value: '0%' }]
+    const { keyFacts } = migratePoolMetadataToV2(legacy).pool.factsheet!
+    expect(keyFacts).to.have.length(1)
+    expect(keyFacts[0]!.title).to.equal('Key facts')
+    expect(keyFacts[0]!.items.some((i) => i.label === 'Historical default rate')).to.equal(true)
+  })
+
+  it('matches service-provider category types case- and separator-insensitively', () => {
+    const legacy = legacyFixture()
+    legacy.pool.issuer.categories = [{ type: 'portfolio_Manager', value: 'Janus Henderson Investors' }]
+    const groups = migratePoolMetadataToV2(legacy).pool.factsheet!.keyFacts
+    const serviceProviders = groups.find((g) => g.id === 'service-providers')
+    expect(serviceProviders?.items).to.deep.equal([
+      { label: 'Portfolio Manager', value: { kind: 'text', text: 'Janus Henderson Investors' } },
     ])
   })
 

--- a/src/utils/poolMetadataMigration.test.ts
+++ b/src/utils/poolMetadataMigration.test.ts
@@ -163,8 +163,44 @@ describe('migratePoolMetadataToV2', () => {
     expect(documents).to.equal(undefined)
   })
 
-  it('omits sections so the app renders defaults', () => {
+  it('omits sections (app renders defaults) when there is no holdings blob', () => {
     expect(migratePoolMetadataToV2(legacyFixture()).pool.factsheet!.sections).to.equal(undefined)
+  })
+
+  it('folds the legacy holdings blob into a table section, faithfully, dropping no column', () => {
+    const legacy = legacyFixture()
+    legacy.holdings = {
+      headers: ['Asset', 'ISIN', 'Amount'],
+      data: [
+        { Asset: 'T-Bill 2026', ISIN: 'US912796RW0', Amount: 1_000_000 },
+        { Asset: 'T-Bill 2027', ISIN: null, Amount: '2500000' },
+      ],
+    }
+    const v2 = migratePoolMetadataToV2(legacy)
+    expect(v2.pool.factsheet!.sections).to.deep.equal([
+      {
+        type: 'table',
+        id: 'holdings',
+        title: 'Holdings',
+        headers: ['Asset', 'ISIN', 'Amount'],
+        rows: [
+          ['T-Bill 2026', 'US912796RW0', 1_000_000], // number stays a number
+          ['T-Bill 2027', '', '2500000'], // null -> '', numeric string stays a string
+        ],
+      },
+    ])
+    // holdings is no longer a top-level field on the v2 document.
+    expect(v2).to.not.have.property('holdings')
+  })
+
+  it('skips the holdings table when headers are empty or data is missing', () => {
+    const emptyHeaders = legacyFixture()
+    emptyHeaders.holdings = { headers: [], data: [{ x: 1 }] }
+    expect(migratePoolMetadataToV2(emptyHeaders).pool.factsheet!.sections).to.equal(undefined)
+
+    const missingData = legacyFixture()
+    missingData.holdings = { headers: ['A'] } as unknown as PoolMetadataV1['holdings']
+    expect(migratePoolMetadataToV2(missingData).pool.factsheet!.sections).to.equal(undefined)
   })
 
   it('is idempotent and returns v2 input unchanged', () => {

--- a/src/utils/poolMetadataMigration.test.ts
+++ b/src/utils/poolMetadataMigration.test.ts
@@ -115,18 +115,24 @@ describe('migratePoolMetadataToV2', () => {
     ])
   })
 
-  it('projects key facts in order, including valueRef apy and categories', () => {
+  it('projects key facts into one untitled group with discriminated values, in order', () => {
     const { keyFacts } = migratePoolMetadataToV2(legacyFixture()).pool.factsheet!
     expect(keyFacts).to.deep.equal([
-      { label: 'Issuer', value: 'Acme Issuer' },
-      { label: 'Asset type', value: 'Public credit - T-Bills' },
-      { label: 'APY', valueRef: 'apy' },
-      { label: 'Pool structure', value: 'revolving' },
-      { label: 'Average asset maturity', value: '63 days' },
-      { label: 'Expense ratio', value: '0.25%' },
-      { label: 'Min. investment', value: '2,500' },
-      { label: 'Trustee', value: 'Acme Trust' },
-      { label: 'Auditor', value: 'Acme Audit' },
+      {
+        type: 'keyFactGroup',
+        id: 'key-facts',
+        items: [
+          { label: 'Issuer', value: { kind: 'text', text: 'Acme Issuer' } },
+          { label: 'Asset type', value: { kind: 'text', text: 'Public credit - T-Bills' } },
+          { label: 'APY', value: { kind: 'ref', ref: 'apy' } },
+          { label: 'Pool structure', value: { kind: 'text', text: 'revolving' } },
+          { label: 'Average asset maturity', value: { kind: 'text', text: '63 days' } },
+          { label: 'Expense ratio', value: { kind: 'text', text: '0.25%' } },
+          { label: 'Min. investment', value: { kind: 'text', text: '2,500' } },
+          { label: 'Trustee', value: { kind: 'text', text: 'Acme Trust' } },
+          { label: 'Auditor', value: { kind: 'text', text: 'Acme Audit' } },
+        ],
+      },
     ])
   })
 
@@ -234,18 +240,18 @@ describe('parsePoolMetadataV2', () => {
     expect(() => parsePoolMetadataV2({ version: 2, pool: {} })).to.throw(/pool.name/)
   })
 
-  it('rejects a chart with both series and dataRef', () => {
-    const bad = clone(mockPoolMetadataV2)
-    const chart = bad.pool.factsheet!.body.find((b) => b.id === 'live-chart') as Record<string, unknown>
-    chart.series = [{ name: 's', data: [{ label: 'a', value: 1 }] }]
-    expect(() => parsePoolMetadataV2(bad)).to.throw(/exactly one of/)
-  })
-
-  it('rejects a chart with neither series nor dataRef', () => {
+  it('rejects a chart whose data has an invalid kind', () => {
     const bad = clone(mockPoolMetadataV2)
     const chart = bad.pool.factsheet!.body.find((b) => b.id === 'inline-chart') as Record<string, unknown>
-    delete chart.series
-    expect(() => parsePoolMetadataV2(bad)).to.throw(/exactly one of/)
+    chart.data = { kind: 'live' }
+    expect(() => parsePoolMetadataV2(bad)).to.throw(/data has an invalid kind/)
+  })
+
+  it('rejects a chart missing its data object', () => {
+    const bad = clone(mockPoolMetadataV2)
+    const chart = bad.pool.factsheet!.body.find((b) => b.id === 'inline-chart') as Record<string, unknown>
+    delete chart.data
+    expect(() => parsePoolMetadataV2(bad)).to.throw(/data must be an object/)
   })
 
   it('rejects an unknown section ref (closed, SDK-enforced registry)', () => {
@@ -280,11 +286,11 @@ describe('parsePoolMetadataV2', () => {
     expect(() => parsePoolMetadataV2(bad)).to.throw(/unknown block type/)
   })
 
-  it('rejects an unknown chart dataRef (closed, SDK-enforced registry)', () => {
+  it('rejects an unknown chart data.dataRef (closed, SDK-enforced registry)', () => {
     const bad = clone(mockPoolMetadataV2)
     const chart = bad.pool.factsheet!.body.find((b) => b.id === 'live-chart') as Record<string, unknown>
-    chart.dataRef = 'someFutureDataset'
-    expect(() => parsePoolMetadataV2(bad)).to.throw(/dataRef is invalid/)
+    chart.data = { kind: 'ref', dataRef: 'someFutureDataset' }
+    expect(() => parsePoolMetadataV2(bad)).to.throw(/data.dataRef is invalid/)
   })
 
   it('rejects an unknown live-table indexer metric (closed, SDK-enforced registry)', () => {
@@ -301,5 +307,53 @@ describe('parsePoolMetadataV2', () => {
       shareClasses: {},
     }
     expect(() => parsePoolMetadataV2(minimal)).to.not.throw()
+  })
+
+  it('rejects a flat KeyFact[] right column (groups only, no back-compat)', () => {
+    const bad = clone(mockPoolMetadataV2)
+    bad.pool.factsheet!.keyFacts = [{ label: 'Issuer', value: { kind: 'text', text: 'x' } }] as never
+    expect(() => parsePoolMetadataV2(bad)).to.throw(/keyFacts\[0\].type must be 'keyFactGroup'/)
+  })
+
+  it('rejects a key fact whose value has an unknown kind', () => {
+    const bad = clone(mockPoolMetadataV2)
+    bad.pool.factsheet!.keyFacts[0]!.items[0]!.value = { kind: 'live' } as never
+    expect(() => parsePoolMetadataV2(bad)).to.throw(/value has an invalid kind/)
+  })
+
+  it('rejects an unknown KeyFactValue ref (closed, SDK-enforced registry)', () => {
+    const bad = clone(mockPoolMetadataV2)
+    bad.pool.factsheet!.keyFacts[0]!.items[0]!.value = { kind: 'ref', ref: 'someFutureRef' } as never
+    expect(() => parsePoolMetadataV2(bad)).to.throw(/value.ref is invalid/)
+  })
+
+  it('accepts the known KeyFactValue refs apy and availableNetworks', () => {
+    const ok = clone(mockPoolMetadataV2)
+    ok.pool.factsheet!.keyFacts[0]!.items[0]!.value = { kind: 'ref', ref: 'availableNetworks' }
+    expect(() => parsePoolMetadataV2(ok)).to.not.throw()
+  })
+
+  it('rejects an icons key fact with a malformed IconRef', () => {
+    const bad = clone(mockPoolMetadataV2)
+    bad.pool.factsheet!.keyFacts[1]!.items[0]!.value = { kind: 'icons', icons: [{ source: 'nope' }] } as never
+    expect(() => parsePoolMetadataV2(bad)).to.throw(/icons\[0\] has an invalid source/)
+  })
+
+  it('accepts both app and metadata IconRefs (app icon key is shape-validated)', () => {
+    const ok = clone(mockPoolMetadataV2)
+    ok.pool.factsheet!.keyFacts[1]!.items[0]!.value = {
+      kind: 'icons',
+      icons: [
+        { source: 'app', key: 'any-future-icon', label: 'X' },
+        { source: 'metadata', file: { uri: 'ipfs://Qm', mime: 'image/svg+xml' } },
+      ],
+    }
+    expect(() => parsePoolMetadataV2(ok)).to.not.throw()
+  })
+
+  it('rejects a key fact group missing items', () => {
+    const bad = clone(mockPoolMetadataV2)
+    delete (bad.pool.factsheet!.keyFacts[0] as Record<string, unknown>).items
+    expect(() => parsePoolMetadataV2(bad)).to.throw(/keyFacts\[0\].items must be an array/)
   })
 })

--- a/src/utils/poolMetadataMigration.test.ts
+++ b/src/utils/poolMetadataMigration.test.ts
@@ -203,6 +203,14 @@ describe('migratePoolMetadataToV2', () => {
     expect(labels).to.not.include('Ratings')
   })
 
+  it('migrates cleanly when issuer.categories is absent (real legacy docs omit it)', () => {
+    const legacy = legacyFixture()
+    delete (legacy.pool.issuer as Record<string, unknown>).categories
+    expect(() => migratePoolMetadataToV2(legacy)).to.not.throw()
+    const { keyFacts } = migratePoolMetadataToV2(legacy).pool.factsheet!
+    expect(keyFacts).to.have.length(1) // Key facts only, no Service providers group
+  })
+
   it('keeps unknown categories in "Key facts" and omits the Service providers group when none match', () => {
     const legacy = legacyFixture()
     legacy.pool.issuer.categories = [{ type: 'Historical default rate', value: '0%' }]

--- a/src/utils/poolMetadataMigration.test.ts
+++ b/src/utils/poolMetadataMigration.test.ts
@@ -27,8 +27,9 @@ function legacyFixture(): PoolMetadataV1 {
         logo: null,
         shortDescription: 'Acme',
         categories: [
-          { type: 'Trustee', value: 'Acme Trust' },
-          { type: 'Auditor', value: 'Acme Audit' },
+          { type: 'Portfolio Manager', value: 'Janus Henderson Investors' }, // manager role -> Key facts
+          { type: 'Custodian', value: 'J.P. Morgan' }, // -> Service providers
+          { type: 'Auditor', value: 'MHA Cayman' }, // -> Service providers
         ],
       },
       links: { executiveSummary: null },
@@ -120,7 +121,7 @@ describe('migratePoolMetadataToV2', () => {
     ])
   })
 
-  it('projects a titled "Key facts" group and splits service-provider categories into "Service providers"', () => {
+  it('projects a titled "Key facts" group (incl. seeded wallet infra + networks) and a "Service providers" group', () => {
     const { keyFacts } = migratePoolMetadataToV2(legacyFixture()).pool.factsheet!
     expect(keyFacts).to.deep.equal([
       {
@@ -135,6 +136,10 @@ describe('migratePoolMetadataToV2', () => {
           { label: 'Average asset maturity', value: { kind: 'text', text: '63 days' } },
           { label: 'Expense ratio', value: { kind: 'text', text: '0.25%' } },
           { label: 'Min. investment', value: { kind: 'text', text: '2,500' } },
+          // 'Portfolio Manager' is a manager role, kept in Key facts.
+          { label: 'Portfolio Manager', value: { kind: 'text', text: 'Janus Henderson Investors' } },
+          { label: 'Wallet infrastructure', value: { kind: 'icons', icons: [{ source: 'app', key: 'fordefi' }] } },
+          { label: 'Available networks', value: { kind: 'ref', ref: 'availableNetworks' } },
           { label: 'Ratings', value: { kind: 'ref', ref: 'ratings' } },
         ],
       },
@@ -142,13 +147,24 @@ describe('migratePoolMetadataToV2', () => {
         type: 'keyFactGroup',
         id: 'service-providers',
         title: 'Service providers',
-        // 'Trustee' and 'Auditor' are known service-provider category types.
         items: [
-          { label: 'Trustee', value: { kind: 'text', text: 'Acme Trust' } },
-          { label: 'Auditor', value: { kind: 'text', text: 'Acme Audit' } },
+          { label: 'Custodian', value: { kind: 'text', text: 'J.P. Morgan' } },
+          { label: 'Auditor', value: { kind: 'text', text: 'MHA Cayman' } },
         ],
       },
     ])
+  })
+
+  it('seeds wallet infrastructure + available networks even with no categories or ratings', () => {
+    const legacy = legacyFixture()
+    legacy.pool.issuer.categories = []
+    legacy.pool.poolRatings = []
+    const { keyFacts } = migratePoolMetadataToV2(legacy).pool.factsheet!
+    expect(keyFacts).to.have.length(1) // no Service providers group
+    const labels = keyFacts[0]!.items.map((i) => i.label)
+    expect(labels).to.include('Wallet infrastructure')
+    expect(labels).to.include('Available networks')
+    expect(labels).to.not.include('Ratings')
   })
 
   it('keeps unknown categories in "Key facts" and omits the Service providers group when none match', () => {
@@ -162,11 +178,11 @@ describe('migratePoolMetadataToV2', () => {
 
   it('matches service-provider category types case- and separator-insensitively', () => {
     const legacy = legacyFixture()
-    legacy.pool.issuer.categories = [{ type: 'portfolio_Manager', value: 'Janus Henderson Investors' }]
+    legacy.pool.issuer.categories = [{ type: 'Fund_Administrator', value: 'Trident Trust' }]
     const groups = migratePoolMetadataToV2(legacy).pool.factsheet!.keyFacts
     const serviceProviders = groups.find((g) => g.id === 'service-providers')
     expect(serviceProviders?.items).to.deep.equal([
-      { label: 'Portfolio Manager', value: { kind: 'text', text: 'Janus Henderson Investors' } },
+      { label: 'Fund Administrator', value: { kind: 'text', text: 'Trident Trust' } },
     ])
   })
 

--- a/src/utils/poolMetadataMigration.test.ts
+++ b/src/utils/poolMetadataMigration.test.ts
@@ -27,8 +27,9 @@ function legacyFixture(): PoolMetadataV1 {
         logo: null,
         shortDescription: 'Acme',
         categories: [
-          { type: 'Portfolio Manager', value: 'Janus Henderson Investors' }, // manager role -> Key facts
-          { type: 'Custodian', value: 'J.P. Morgan' }, // -> Service providers
+          { type: 'Investment Manager', value: 'Anemoy Asset Management Ltd.' }, // absorbed by Issuer (dropped)
+          { type: 'Sub-Investment Manager', value: 'Janus Henderson Investors' }, // -> Portfolio Manager (SP)
+          { type: 'Fund Administrator', value: 'Trident Trust Company (Cayman) Ltd' }, // -> Service providers
           { type: 'Auditor', value: 'MHA Cayman' }, // -> Service providers
         ],
       },
@@ -136,8 +137,7 @@ describe('migratePoolMetadataToV2', () => {
           { label: 'Average asset maturity', value: { kind: 'text', text: '63 days' } },
           { label: 'Expense ratio', value: { kind: 'text', text: '0.25%' } },
           { label: 'Min. investment', value: { kind: 'text', text: '2,500' } },
-          // 'Portfolio Manager' is a manager role, kept in Key facts.
-          { label: 'Portfolio Manager', value: { kind: 'text', text: 'Janus Henderson Investors' } },
+          // Investment Manager is absorbed into Issuer (no row); the other three are service providers.
           { label: 'Wallet infrastructure', value: { kind: 'icons', icons: [{ source: 'app', key: 'fordefi' }] } },
           { label: 'Available networks', value: { kind: 'ref', ref: 'availableNetworks' } },
           { label: 'Ratings', value: { kind: 'ref', ref: 'ratings' } },
@@ -148,11 +148,21 @@ describe('migratePoolMetadataToV2', () => {
         id: 'service-providers',
         title: 'Service providers',
         items: [
-          { label: 'Custodian', value: { kind: 'text', text: 'J.P. Morgan' } },
+          { label: 'Portfolio Manager', value: { kind: 'text', text: 'Janus Henderson Investors' } },
+          { label: 'Fund Administrator', value: { kind: 'text', text: 'Trident Trust Company (Cayman) Ltd' } },
           { label: 'Auditor', value: { kind: 'text', text: 'MHA Cayman' } },
         ],
       },
     ])
+  })
+
+  it('absorbs the Investment Manager category into the Issuer key fact (drops its own row)', () => {
+    const { keyFacts } = migratePoolMetadataToV2(legacyFixture()).pool.factsheet!
+    const allItems = keyFacts.flatMap((g) => g.items)
+    expect(allItems.filter((i) => i.label === 'Issuer')).to.have.length(1)
+    expect(allItems.some((i) => i.value.kind === 'text' && i.value.text === 'Anemoy Asset Management Ltd.')).to.equal(
+      false
+    )
   })
 
   it('seeds wallet infrastructure + available networks even with no categories or ratings', () => {

--- a/src/utils/poolMetadataMigration.test.ts
+++ b/src/utils/poolMetadataMigration.test.ts
@@ -30,7 +30,7 @@ function legacyFixture(): PoolMetadataV1 {
           { type: 'Investment Manager', value: 'Anemoy Asset Management Ltd.' }, // absorbed by Issuer (dropped)
           { type: 'Sub-Investment Manager', value: 'Janus Henderson Investors' }, // -> Portfolio Manager (SP)
           { type: 'Fund Administrator', value: 'Trident Trust Company (Cayman) Ltd' }, // -> Service providers
-          { type: 'Auditor', value: 'MHA Cayman' }, // -> Service providers
+          { type: 'Auditor', value: 'MHA Cayman ' }, // -> Service providers (trailing space, trimmed on migrate)
         ],
       },
       links: { executiveSummary: null },
@@ -69,6 +69,11 @@ function legacyFixture(): PoolMetadataV1 {
     loanTemplates: [{ id: 'tpl', createdAt: '2024-01-01' }],
     addressLabels: { '0xabc': 'Treasury' },
     workflowPolicies: [],
+    withdrawManagers: {
+      '0x6756e091ae798a8e51e12e27ee8facdf': [
+        { assetAddress: '0xa0b8', chainId: '1', manager: '0x1a3b', label: 'C-AC' },
+      ],
+    },
   }
 }
 
@@ -103,10 +108,31 @@ describe('migratePoolMetadataToV2', () => {
     expect(v2.shareClasses['0xda64aae939e4d3a981004619f1709d8f']!.apy).to.equal('90d365')
   })
 
-  it('preserves engine fields verbatim', () => {
+  it('preserves engine fields verbatim (incl. withdrawManagers)', () => {
     const v2 = migratePoolMetadataToV2(legacyFixture())
     expect(v2.addressLabels).to.deep.equal({ '0xabc': 'Treasury' })
     expect(v2.workflowPolicies).to.deep.equal([])
+    expect(v2.withdrawManagers).to.deep.equal({
+      '0x6756e091ae798a8e51e12e27ee8facdf': [
+        { assetAddress: '0xa0b8', chainId: '1', manager: '0x1a3b', label: 'C-AC' },
+      ],
+    })
+  })
+
+  it('drops a stray pool.report (singular) non-schema field', () => {
+    const legacy = legacyFixture()
+    ;(legacy.pool as Record<string, unknown>).report = { author: { name: '', title: '', avatar: null }, url: '' }
+    const v2 = migratePoolMetadataToV2(legacy)
+    expect(v2.pool).to.not.have.property('report')
+  })
+
+  it('trims whitespace from migrated text values', () => {
+    // legacyFixture's Auditor value carries a trailing space.
+    const serviceProviders = migratePoolMetadataToV2(legacyFixture()).pool.factsheet!.keyFacts.find(
+      (g) => g.id === 'service-providers'
+    )
+    const auditor = serviceProviders!.items.find((i) => i.label === 'Auditor')!
+    expect(auditor.value).to.deep.equal({ kind: 'text', text: 'MHA Cayman' })
   })
 
   it('preserves poolRatings verbatim as a typed field (incl. reportFile)', () => {

--- a/src/utils/poolMetadataMigration.test.ts
+++ b/src/utils/poolMetadataMigration.test.ts
@@ -315,6 +315,93 @@ describe('migratePoolMetadataToV2', () => {
     expect(isPoolMetadataV2(v2)).to.equal(true)
     expect(() => parsePoolMetadataV2(v2)).to.not.throw()
   })
+
+  describe('intra-v2 upgrade (documents written by an earlier SDK)', () => {
+    // The shape an SDK <= 1.16.0 produced: flat keyFacts, chart series/dataRef, top-level holdings.
+    const oldV2 = () =>
+      ({
+        version: 2,
+        pool: {
+          name: 'Old V2 Pool',
+          factsheet: {
+            keyFacts: [
+              { label: 'Issuer', value: 'Acme' },
+              { label: 'APY', valueRef: 'apy' },
+            ],
+            body: [
+              { type: 'chart', id: 'c1', chartType: 'line', series: [{ name: 's', data: [{ x: 1, y: 2 }] }] },
+              { type: 'chart', id: 'c2', chartType: 'donut', dataRef: 'apyVsBenchmarks' },
+              {
+                type: 'tabGroup',
+                id: 'tg',
+                tabs: [
+                  {
+                    label: 'T',
+                    block: {
+                      type: 'chart',
+                      id: 'c3',
+                      chartType: 'bar',
+                      series: [{ name: 's', data: [{ label: 'a', value: 1 }] }],
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        shareClasses: {},
+        holdings: { headers: ['A'], data: [{ A: 'x' }] },
+      }) as unknown as PoolMetadataV2
+
+    it('upgrades flat keyFacts into a single Key facts group with discriminated values', () => {
+      const { keyFacts } = migratePoolMetadataToV2(oldV2()).pool.factsheet!
+      expect(keyFacts).to.deep.equal([
+        {
+          type: 'keyFactGroup',
+          id: 'key-facts',
+          title: 'Key facts',
+          items: [
+            { label: 'Issuer', value: { kind: 'text', text: 'Acme' } },
+            { label: 'APY', value: { kind: 'ref', ref: 'apy' } },
+          ],
+        },
+      ])
+    })
+
+    it('upgrades chart series/dataRef into discriminated data (incl. inside tab groups)', () => {
+      const body = migratePoolMetadataToV2(oldV2()).pool.factsheet!.body
+      const c1 = body.find((b) => b.id === 'c1') as Record<string, unknown>
+      expect(c1.data).to.deep.equal({ kind: 'inline', series: [{ name: 's', data: [{ x: 1, y: 2 }] }] })
+      expect(c1).to.not.have.property('series')
+      const c2 = body.find((b) => b.id === 'c2') as Record<string, unknown>
+      expect(c2.data).to.deep.equal({ kind: 'ref', dataRef: 'apyVsBenchmarks' })
+      const tg = body.find((b) => b.id === 'tg') as { tabs: { block: Record<string, unknown> }[] }
+      expect(tg.tabs[0]!.block.data).to.deep.equal({
+        kind: 'inline',
+        series: [{ name: 's', data: [{ label: 'a', value: 1 }] }],
+      })
+    })
+
+    it('folds a top-level holdings blob into a factsheet table section and removes the top-level field', () => {
+      const v2 = migratePoolMetadataToV2(oldV2())
+      expect(v2).to.not.have.property('holdings')
+      const holdings = v2.pool.factsheet!.sections!.find((s) => s.id === 'holdings')
+      expect(holdings).to.deep.equal({
+        type: 'table',
+        id: 'holdings',
+        title: 'Holdings',
+        headers: ['A'],
+        rows: [['x']],
+      })
+    })
+
+    it('produces a document that passes the current validator, and is then idempotent', () => {
+      const upgraded = migratePoolMetadataToV2(oldV2())
+      expect(() => parsePoolMetadataV2(upgraded)).to.not.throw()
+      // Already current shape -> returned unchanged (same reference).
+      expect(migratePoolMetadataToV2(upgraded)).to.equal(upgraded)
+    })
+  })
 })
 
 describe('parsePoolMetadataV2', () => {

--- a/src/utils/poolMetadataMigration.ts
+++ b/src/utils/poolMetadataMigration.ts
@@ -9,6 +9,7 @@ import {
   isPoolMetadataV2,
   type KeyFact,
   type KeyFactGroup,
+  type KeyFactValue,
   type LayoutItem,
   type LegacyApyMode,
   type LiveDataset,
@@ -17,6 +18,7 @@ import {
   type PoolMetadataV1,
   type PoolMetadataV2,
   type SectionRef,
+  type TableBlock,
   type Visibility,
 } from '../types/poolMetadata.js'
 
@@ -49,6 +51,30 @@ function formatMinInvestment(value: number): string {
 /** Tolerates legacy docs that omit (or malform) an array field by treating it as empty. */
 function asArray<T>(value: T[] | undefined): T[] {
   return Array.isArray(value) ? value : []
+}
+
+/**
+ * Folds a legacy off-chain `{ headers, data }` holdings blob into a `table` section, preserving
+ * every column verbatim (numbers stay numbers, null/undefined -> '', other values stringified +
+ * trimmed). Returns null when there are no headers or no data.
+ */
+function holdingsTableBlock(holdings: PoolMetadataV1['holdings']): TableBlock | null {
+  if (!holdings || !Array.isArray(holdings.headers) || holdings.headers.length === 0 || !Array.isArray(holdings.data)) {
+    return null
+  }
+  const { headers, data } = holdings
+  return {
+    type: 'table',
+    id: 'holdings',
+    title: 'Holdings',
+    headers,
+    rows: data.map((row) =>
+      headers.map((header) => {
+        const value = row[header]
+        return typeof value === 'number' ? value : value == null ? '' : String(value).trim()
+      })
+    ),
+  }
 }
 
 /** Normalizes an issuer category `type` for matching (case- and separator-insensitive). */
@@ -123,13 +149,10 @@ function buildFactsheet(
     keyFactItems.push({ label: 'Min. investment', value: text(formatMinInvestment(minInitialInvestment)) })
   }
 
-  // Issuer categories are split: known service-provider roles go into a "Service providers" group,
-  // everything else stays in "Key facts". Matching is case/separator-insensitive; an unknown type
-  // falls back to "Key facts" (the seed is ops-editable, so a miss is low-cost).
   const serviceProviderItems: KeyFact[] = []
   for (const category of asArray(issuer.categories)) {
     const key = normalizeCategoryType(category.type)
-    if (ABSORBED_CATEGORY_TYPES.has(key)) continue // e.g. Investment Manager -> the Issuer key fact
+    if (ABSORBED_CATEGORY_TYPES.has(key)) continue
     const label = SERVICE_PROVIDER_CATEGORIES.get(key)
     if (label) {
       serviceProviderItems.push({ label, value: text(category.value) })
@@ -138,22 +161,20 @@ function buildFactsheet(
     }
   }
 
-  // Seeded for every migrated pool (app-derived, no v1 source): the wallet infrastructure icon and
-  // the live "available networks" ref. Both are ops-editable afterwards.
+  // Seeded unconditionally because v1 has no source field for either: the app derives the deployed
+  // chains, and wallet infrastructure is currently Fordefi for all pools. Ops can edit/remove after.
   keyFactItems.push({
     label: 'Wallet infrastructure',
     value: { kind: 'icons', icons: [{ source: 'app', key: 'fordefi' }] },
   })
   keyFactItems.push({ label: 'Available networks', value: { kind: 'ref', ref: 'availableNetworks' } })
 
-  // Ratings render via the `ratings` ref widget, reading the typed `poolRatings` field verbatim
-  // (agency/value/reportUrl/reportFile). The data is not duplicated into the key fact.
   if (asArray(poolRatings).length > 0) {
     keyFactItems.push({ label: 'Ratings', value: { kind: 'ref', ref: 'ratings' } })
   }
 
-  // The right column is groups only. Seed a titled "Key facts" group, plus a "Service providers"
-  // group when any category matched.
+  // Right column is groups only (no bare key facts). The "Service providers" group is added only
+  // when at least one category mapped to it.
   const keyFacts: KeyFactGroup[] = [{ type: 'keyFactGroup', id: 'key-facts', title: 'Key facts', items: keyFactItems }]
   if (serviceProviderItems.length > 0) {
     keyFacts.push({
@@ -190,32 +211,15 @@ function buildFactsheet(
   }
   body.push({ type: 'section', id: 'performance', ref: 'onchainMetrics' })
 
-  // Legacy off-chain `holdings` ({ headers, data }) is folded into the factsheet as a `table`
-  // section, faithfully (no column dropped). Skipped entirely when there are no headers or no data.
-  const sections: LayoutItem[] = []
-  if (holdings && Array.isArray(holdings.headers) && holdings.headers.length > 0 && Array.isArray(holdings.data)) {
-    const { headers, data } = holdings
-    sections.push({
-      type: 'table',
-      id: 'holdings',
-      title: 'Holdings',
-      headers,
-      rows: data.map((row) =>
-        headers.map((header) => {
-          const value = row[header]
-          return typeof value === 'number' ? value : value == null ? '' : String(value).trim()
-        })
-      ),
-    })
-  }
-
+  const holdingsBlock = holdingsTableBlock(holdings)
   // `sections` is omitted (so the invest app renders its defaults) unless we have a holdings table.
-  return sections.length > 0 ? { body, keyFacts, sections } : { body, keyFacts }
+  return holdingsBlock ? { body, keyFacts, sections: [holdingsBlock] } : { body, keyFacts }
 }
 
 /**
  * Pure, idempotent legacy -> v2 migration. Performs no IPFS/network access so it stays
- * unit-testable. Returns the input unchanged when it is already v2.
+ * unit-testable. A document already at the current v2 shape is returned unchanged; a v2 document
+ * written by an earlier SDK is normalized forward via {@link upgradeLegacyV2}.
  *
  * - Strips fields unused by every consumer (`newInvestmentsStatus`, `reports`, `loanTemplates`,
  *   `issuer.repName/shortDescription`, onboarding extras) and reshapes `issuer`. `poolRatings` is
@@ -225,7 +229,7 @@ function buildFactsheet(
  *   blob into a `table` section (`id: 'holdings'`); `holdings` is not carried as a top-level field.
  */
 export function migratePoolMetadataToV2(legacy: PoolMetadata): PoolMetadataV2 {
-  if (isPoolMetadataV2(legacy)) return legacy
+  if (isPoolMetadataV2(legacy)) return upgradeLegacyV2(legacy)
 
   const {
     pool,
@@ -238,12 +242,13 @@ export function migratePoolMetadataToV2(legacy: PoolMetadata): PoolMetadataV2 {
     withdrawManagers,
   } = legacy
   const { issuer, poolRatings, ...restPool } = pool
-  // Explicitly drop fields that v2 does not carry. `report` (singular) is a stray non-schema field
-  // seen in some legacy documents (the real reports array is `reports`, dropped above).
+  // Explicitly drop fields that v2 does not carry. `report` (singular) and `poolStatus` are stray
+  // non-schema fields seen in some legacy documents (the real fields are `reports` and `status`).
   delete (restPool as Record<string, unknown>).newInvestmentsStatus
   delete (restPool as Record<string, unknown>).reports
   delete (restPool as Record<string, unknown>).details
   delete (restPool as Record<string, unknown>).report
+  delete (restPool as Record<string, unknown>).poolStatus
 
   const migratedShareClasses: PoolMetadataV2['shareClasses'] = {}
   for (const [scId, shareClass] of Object.entries(shareClasses)) {
@@ -274,6 +279,103 @@ export function migratePoolMetadataToV2(legacy: PoolMetadata): PoolMetadataV2 {
     ...(workflowPolicies !== undefined ? { workflowPolicies } : {}),
     ...(withdrawManagers !== undefined ? { withdrawManagers } : {}),
   }
+}
+
+/* ================================================================================================
+ * Intra-v2 upgrade: normalize a v2 document written by an earlier SDK to the current v2 shape
+ * ============================================================================================== */
+
+function isKeyFactGroup(value: unknown): boolean {
+  return typeof value === 'object' && value !== null && (value as Record<string, unknown>).type === 'keyFactGroup'
+}
+
+/** Converts an earlier-SDK flat KeyFact (`{ value?: string; valueRef?: 'apy' }`) to the discriminated shape. */
+function upgradeKeyFact(old: Record<string, unknown>): KeyFact {
+  const { value, valueRef, ...rest } = old
+  let next: KeyFactValue
+  if (valueRef === 'apy') next = { kind: 'ref', ref: 'apy' }
+  else if (value !== null && typeof value === 'object' && 'kind' in (value as object)) next = value as KeyFactValue
+  else next = { kind: 'text', text: typeof value === 'string' ? value : '' }
+  return { ...(rest as Omit<KeyFact, 'value'>), value: next }
+}
+
+/** True if `item` is (or, for a tabGroup, contains) a chart still using the `series`/`dataRef` shape. */
+function hasLegacyChart(item: unknown): boolean {
+  if (typeof item !== 'object' || item === null) return false
+  const block = item as Record<string, unknown>
+  if (block.type === 'chart') {
+    return block.data === undefined && (block.series !== undefined || block.dataRef !== undefined)
+  }
+  if (block.type === 'tabGroup' && Array.isArray(block.tabs)) {
+    return block.tabs.some((tab) => hasLegacyChart((tab as Record<string, unknown>)?.block))
+  }
+  return false
+}
+
+/** Converts an earlier-SDK chart block (`series?`/`dataRef?`) to the discriminated `data` field, in place. */
+function upgradeChartBlockInPlace(block: Record<string, unknown>): void {
+  if (block.type === 'chart' && block.data === undefined) {
+    if (Array.isArray(block.series)) block.data = { kind: 'inline', series: block.series }
+    else if (typeof block.dataRef === 'string') block.data = { kind: 'ref', dataRef: block.dataRef }
+    delete block.series
+    delete block.dataRef
+  }
+  if (block.type === 'tabGroup' && Array.isArray(block.tabs)) {
+    for (const tab of block.tabs) {
+      const inner = (tab as Record<string, unknown>)?.block
+      if (inner && typeof inner === 'object') upgradeChartBlockInPlace(inner as Record<string, unknown>)
+    }
+  }
+}
+
+/**
+ * Normalizes a document already at `version: 2` but written by an earlier SDK whose v2 shape differs:
+ * a flat `keyFacts: KeyFact[]` (now `KeyFactGroup[]`), chart blocks with `series`/`dataRef` (now a
+ * discriminated `data`), and a top-level `holdings` blob (now a factsheet `table` section). Without
+ * this, `update()` would re-validate such a document against the current validator and throw, with no
+ * upgrade path. Returns the input unchanged (same reference) when it is already the current shape.
+ */
+function upgradeLegacyV2(doc: PoolMetadataV2): PoolMetadataV2 {
+  const raw = doc as unknown as Record<string, unknown>
+  const pool = (raw.pool ?? {}) as Record<string, unknown>
+  const factsheet = pool.factsheet as Record<string, unknown> | undefined
+  const keyFacts = factsheet?.keyFacts
+  const layoutItems = [...asArray(factsheet?.body as unknown[]), ...asArray(factsheet?.sections as unknown[])]
+
+  const needsKeyFactUpgrade = Array.isArray(keyFacts) && keyFacts.some((item) => !isKeyFactGroup(item))
+  const needsHoldingsFold = raw.holdings != null
+  const needsChartUpgrade = layoutItems.some(hasLegacyChart)
+  if (!needsKeyFactUpgrade && !needsHoldingsFold && !needsChartUpgrade) return doc
+
+  const next = JSON.parse(JSON.stringify(doc)) as Record<string, unknown>
+  const nextPool = next.pool as Record<string, unknown>
+  const nextFactsheet = nextPool.factsheet as Record<string, unknown> | undefined
+
+  if (nextFactsheet) {
+    if (needsKeyFactUpgrade) {
+      // Wrap the flat list into one titled "Key facts" group, converting each item's value.
+      const items = (nextFactsheet.keyFacts as Record<string, unknown>[]).map(upgradeKeyFact)
+      nextFactsheet.keyFacts = [{ type: 'keyFactGroup', id: 'key-facts', title: 'Key facts', items }]
+    }
+    if (needsChartUpgrade) {
+      for (const item of [
+        ...asArray(nextFactsheet.body as unknown[]),
+        ...asArray(nextFactsheet.sections as unknown[]),
+      ]) {
+        if (item && typeof item === 'object') upgradeChartBlockInPlace(item as Record<string, unknown>)
+      }
+    }
+  }
+
+  if (needsHoldingsFold) {
+    const holdingsBlock = holdingsTableBlock(raw.holdings as PoolMetadataV1['holdings'])
+    delete next.holdings
+    if (holdingsBlock && nextFactsheet) {
+      nextFactsheet.sections = [...asArray(nextFactsheet.sections as LayoutItem[]), holdingsBlock]
+    }
+  }
+
+  return next as unknown as PoolMetadataV2
 }
 
 /* ================================================================================================

--- a/src/utils/poolMetadataMigration.ts
+++ b/src/utils/poolMetadataMigration.ts
@@ -46,6 +46,11 @@ function formatMinInvestment(value: number): string {
   return value.toLocaleString('en-US')
 }
 
+/** Tolerates legacy docs that omit (or malform) an array field by treating it as empty. */
+function asArray<T>(value: T[] | undefined): T[] {
+  return Array.isArray(value) ? value : []
+}
+
 /** Normalizes an issuer category `type` for matching (case- and separator-insensitive). */
 function normalizeCategoryType(type: string): string {
   return type.toLowerCase().replace(/[\s_-]/g, '')
@@ -122,7 +127,7 @@ function buildFactsheet(
   // everything else stays in "Key facts". Matching is case/separator-insensitive; an unknown type
   // falls back to "Key facts" (the seed is ops-editable, so a miss is low-cost).
   const serviceProviderItems: KeyFact[] = []
-  for (const category of issuer.categories) {
+  for (const category of asArray(issuer.categories)) {
     const key = normalizeCategoryType(category.type)
     if (ABSORBED_CATEGORY_TYPES.has(key)) continue // e.g. Investment Manager -> the Issuer key fact
     const label = SERVICE_PROVIDER_CATEGORIES.get(key)
@@ -143,7 +148,7 @@ function buildFactsheet(
 
   // Ratings render via the `ratings` ref widget, reading the typed `poolRatings` field verbatim
   // (agency/value/reportUrl/reportFile). The data is not duplicated into the key fact.
-  if ((poolRatings ?? []).length > 0) {
+  if (asArray(poolRatings).length > 0) {
     keyFactItems.push({ label: 'Ratings', value: { kind: 'ref', ref: 'ratings' } })
   }
 
@@ -163,12 +168,12 @@ function buildFactsheet(
   if (issuer.description) {
     body.push({ type: 'text', id: 'overview', title: 'Overview', body: issuer.description })
   }
-  ;(details ?? []).forEach((detail, index) => {
+  asArray(details).forEach((detail, index) => {
     body.push({ type: 'text', id: `detail-${index}`, title: detail.title, body: detail.body })
   })
   // Ratings reports are surfaced two ways: a Documents body block (markdown links to the report
   // PDFs) and the `ratings` key-fact ref pill above. Both read the same typed `poolRatings` field.
-  const ratingsWithReports = (poolRatings ?? []).filter(
+  const ratingsWithReports = asArray(poolRatings).filter(
     (rating) => rating.reportFile?.uri && isSafeDocumentUri(rating.reportFile.uri)
   )
   if (ratingsWithReports.length > 0) {
@@ -188,7 +193,7 @@ function buildFactsheet(
   // Legacy off-chain `holdings` ({ headers, data }) is folded into the factsheet as a `table`
   // section, faithfully (no column dropped). Skipped entirely when there are no headers or no data.
   const sections: LayoutItem[] = []
-  if (holdings && holdings.headers.length > 0 && holdings.data) {
+  if (holdings && Array.isArray(holdings.headers) && holdings.headers.length > 0 && Array.isArray(holdings.data)) {
     const { headers, data } = holdings
     sections.push({
       type: 'table',

--- a/src/utils/poolMetadataMigration.ts
+++ b/src/utils/poolMetadataMigration.ts
@@ -52,18 +52,25 @@ function normalizeCategoryType(type: string): string {
 }
 
 /**
- * Issuer-category `type` values (normalized) that migrate into the "Service providers" key-fact
- * group, mapped to their display label. Anything not listed stays in "Key facts" (the seed is
- * ops-editable, so an unmatched type is low-cost). Manager roles (portfolio/investment/asset
- * manager) are intentionally NOT here; they stay in Key facts. `administrator` is an alias of
- * Fund Administrator.
+ * Issuer-category `type` values (normalized) that migrate into the "Service providers" group, mapped
+ * to their v2 display label (the v1 vocabulary differs from v2, e.g. "Sub-Investment Manager" is the
+ * v2 "Portfolio Manager"). Anything not listed stays in "Key facts" with its raw label (the seed is
+ * ops-editable, so an unmatched type is low-cost). `administrator` is an alias of Fund Administrator.
  */
 const SERVICE_PROVIDER_CATEGORIES = new Map<string, string>([
+  ['subinvestmentmanager', 'Portfolio Manager'],
   ['custodian', 'Custodian'],
   ['fundadministrator', 'Fund Administrator'],
   ['administrator', 'Fund Administrator'],
   ['auditor', 'Auditor'],
 ])
+
+/**
+ * Issuer-category `type` values (normalized) dropped from the factsheet because they are already
+ * represented elsewhere: "Investment Manager" is absorbed by the `Issuer` key fact (from
+ * `issuer.name`), so it is not rendered as its own row.
+ */
+const ABSORBED_CATEGORY_TYPES = new Set(['investmentmanager'])
 
 /** Document links only carry web/IPFS URIs; anything else (e.g. `javascript:`) is dropped. */
 function isSafeDocumentUri(uri: string): boolean {
@@ -115,7 +122,9 @@ function buildFactsheet(
   // falls back to "Key facts" (the seed is ops-editable, so a miss is low-cost).
   const serviceProviderItems: KeyFact[] = []
   for (const category of issuer.categories) {
-    const label = SERVICE_PROVIDER_CATEGORIES.get(normalizeCategoryType(category.type))
+    const key = normalizeCategoryType(category.type)
+    if (ABSORBED_CATEGORY_TYPES.has(key)) continue // e.g. Investment Manager -> the Issuer key fact
+    const label = SERVICE_PROVIDER_CATEGORIES.get(key)
     if (label) {
       serviceProviderItems.push({ label, value: text(category.value) })
     } else {

--- a/src/utils/poolMetadataMigration.ts
+++ b/src/utils/poolMetadataMigration.ts
@@ -61,7 +61,11 @@ function escapeMarkdownText(text: string): string {
  * a migrated pool must render the same content, so legacy fields are projected into ordered key
  * facts + body blocks. The output is a sensible, ops-editable seed, not a frozen contract.
  */
-function buildFactsheet(pool: PoolMetadataV1['pool'], shareClasses: PoolMetadataV1['shareClasses']): Factsheet {
+function buildFactsheet(
+  pool: PoolMetadataV1['pool'],
+  shareClasses: PoolMetadataV1['shareClasses'],
+  holdings: PoolMetadataV1['holdings']
+): Factsheet {
   const { issuer, asset, poolStructure, expenseRatio, details, poolRatings } = pool
   const firstShareClass = Object.values(shareClasses)[0]
 
@@ -111,8 +115,27 @@ function buildFactsheet(pool: PoolMetadataV1['pool'], shareClasses: PoolMetadata
   }
   body.push({ type: 'section', id: 'performance', ref: 'onchainMetrics' })
 
-  // `sections` is omitted so the invest app renders its default sections.
-  return { body, keyFacts }
+  // Legacy off-chain `holdings` ({ headers, data }) is folded into the factsheet as a `table`
+  // section, faithfully (no column dropped). Skipped entirely when there are no headers or no data.
+  const sections: LayoutItem[] = []
+  if (holdings && holdings.headers.length > 0 && holdings.data) {
+    const { headers, data } = holdings
+    sections.push({
+      type: 'table',
+      id: 'holdings',
+      title: 'Holdings',
+      headers,
+      rows: data.map((row) =>
+        headers.map((header) => {
+          const value = row[header]
+          return typeof value === 'number' ? value : value == null ? '' : String(value)
+        })
+      ),
+    })
+  }
+
+  // `sections` is omitted (so the invest app renders its defaults) unless we have a holdings table.
+  return sections.length > 0 ? { body, keyFacts, sections } : { body, keyFacts }
 }
 
 /**
@@ -122,7 +145,8 @@ function buildFactsheet(pool: PoolMetadataV1['pool'], shareClasses: PoolMetadata
  * - Strips fields unused by every consumer (`newInvestmentsStatus`, `reports`, `loanTemplates`,
  *   `issuer.repName/shortDescription`, onboarding extras) and reshapes `issuer`/`poolRatings`.
  * - Maps legacy APY modes across `shareClasses[*].apy`.
- * - Projects the legacy display fields into `pool.factsheet`.
+ * - Projects the legacy display fields into `pool.factsheet`, and folds the off-chain `holdings`
+ *   blob into a `table` section (`id: 'holdings'`); `holdings` is not carried as a top-level field.
  */
 export function migratePoolMetadataToV2(legacy: PoolMetadata): PoolMetadataV2 {
   if (isPoolMetadataV2(legacy)) return legacy
@@ -145,7 +169,8 @@ export function migratePoolMetadataToV2(legacy: PoolMetadata): PoolMetadataV2 {
       ...restPool,
       issuer: { name: issuer.name, email: issuer.email, logo: issuer.logo },
       poolRatings: poolRatings?.map(({ reportFile: _reportFile, ...rating }) => rating),
-      factsheet: buildFactsheet(pool, shareClasses),
+      // Legacy `holdings` is folded into the factsheet here and not carried as a top-level field.
+      factsheet: buildFactsheet(pool, shareClasses, holdings),
     },
     shareClasses: migratedShareClasses,
     ...(merkleProofManager !== undefined ? { merkleProofManager } : {}),
@@ -157,7 +182,6 @@ export function migratePoolMetadataToV2(legacy: PoolMetadata): PoolMetadataV2 {
           },
         }
       : {}),
-    ...(holdings !== undefined ? { holdings } : {}),
     ...(addressLabels !== undefined ? { addressLabels } : {}),
     ...(workflowPolicies !== undefined ? { workflowPolicies } : {}),
   }
@@ -394,7 +418,7 @@ function validateFactsheet(factsheet: unknown): void {
  * Hand-rolled structural validator for v2 pool metadata, in the style of
  * {@link parseMarketplaceCatalog}. Validates the discriminant (`version === 2`), `pool.name`, and
  * the full `pool.factsheet` content model (the layout the SDK is responsible for). Engine fields
- * (`shareClasses`, `workflowPolicies`, `holdings`, `addressLabels`, …) are passed through
+ * (`shareClasses`, `workflowPolicies`, `addressLabels`, …) are passed through
  * unchecked here — they are validated where they are consumed (e.g. workflows via
  * {@link parseMarketplaceCatalog}). Throws `pool metadata v2: …` on the first malformed field;
  * tolerates missing optionals (visibility defaults to `'public'` app-side). Returns the input

--- a/src/utils/poolMetadataMigration.ts
+++ b/src/utils/poolMetadataMigration.ts
@@ -96,7 +96,8 @@ function buildFactsheet(
   const { issuer, asset, poolStructure, expenseRatio, details, poolRatings } = pool
   const firstShareClass = Object.values(shareClasses)[0]
 
-  const text = (value: string): KeyFact['value'] => ({ kind: 'text', text: value })
+  // Trim text key-fact values (issuer/category strings sometimes carry stray whitespace).
+  const text = (value: string): KeyFact['value'] => ({ kind: 'text', text: value.trim() })
 
   const keyFactItems: KeyFact[] = [
     { label: 'Issuer', value: text(issuer.name) },
@@ -197,7 +198,7 @@ function buildFactsheet(
       rows: data.map((row) =>
         headers.map((header) => {
           const value = row[header]
-          return typeof value === 'number' ? value : value == null ? '' : String(value)
+          return typeof value === 'number' ? value : value == null ? '' : String(value).trim()
         })
       ),
     })
@@ -221,12 +222,23 @@ function buildFactsheet(
 export function migratePoolMetadataToV2(legacy: PoolMetadata): PoolMetadataV2 {
   if (isPoolMetadataV2(legacy)) return legacy
 
-  const { pool, shareClasses, onboarding, merkleProofManager, holdings, addressLabels, workflowPolicies } = legacy
+  const {
+    pool,
+    shareClasses,
+    onboarding,
+    merkleProofManager,
+    holdings,
+    addressLabels,
+    workflowPolicies,
+    withdrawManagers,
+  } = legacy
   const { issuer, poolRatings, ...restPool } = pool
-  // Explicitly drop fields that v2 does not carry.
+  // Explicitly drop fields that v2 does not carry. `report` (singular) is a stray non-schema field
+  // seen in some legacy documents (the real reports array is `reports`, dropped above).
   delete (restPool as Record<string, unknown>).newInvestmentsStatus
   delete (restPool as Record<string, unknown>).reports
   delete (restPool as Record<string, unknown>).details
+  delete (restPool as Record<string, unknown>).report
 
   const migratedShareClasses: PoolMetadataV2['shareClasses'] = {}
   for (const [scId, shareClass] of Object.entries(shareClasses)) {
@@ -255,6 +267,7 @@ export function migratePoolMetadataToV2(legacy: PoolMetadata): PoolMetadataV2 {
       : {}),
     ...(addressLabels !== undefined ? { addressLabels } : {}),
     ...(workflowPolicies !== undefined ? { workflowPolicies } : {}),
+    ...(withdrawManagers !== undefined ? { withdrawManagers } : {}),
   }
 }
 

--- a/src/utils/poolMetadataMigration.ts
+++ b/src/utils/poolMetadataMigration.ts
@@ -46,6 +46,34 @@ function formatMinInvestment(value: number): string {
   return value.toLocaleString('en-US')
 }
 
+/** Normalizes an issuer category `type` for matching (case- and separator-insensitive). */
+function normalizeCategoryType(type: string): string {
+  return type.toLowerCase().replace(/[\s_-]/g, '')
+}
+
+/**
+ * Issuer-category `type` values (normalized) that migrate into the "Service providers" key-fact
+ * group, mapped to their display label. Anything not listed stays in "Key facts". This is a seed
+ * heuristic, not a validated registry: an unmatched type is simply left in "Key facts", so the list
+ * is safe to extend. NOTE: confirm/extend this against the production category vocabulary.
+ */
+const SERVICE_PROVIDER_CATEGORIES = new Map<string, string>([
+  ['portfoliomanager', 'Portfolio Manager'],
+  ['investmentmanager', 'Investment Manager'],
+  ['assetmanager', 'Asset Manager'],
+  ['custodian', 'Custodian'],
+  ['subcustodian', 'Sub-Custodian'],
+  ['administrator', 'Administrator'],
+  ['fundadministrator', 'Fund Administrator'],
+  ['auditor', 'Auditor'],
+  ['trustee', 'Trustee'],
+  ['transferagent', 'Transfer Agent'],
+  ['payingagent', 'Paying Agent'],
+  ['legalcounsel', 'Legal Counsel'],
+  ['legaladvisor', 'Legal Advisor'],
+  ['primebroker', 'Prime Broker'],
+])
+
 /** Document links only carry web/IPFS URIs; anything else (e.g. `javascript:`) is dropped. */
 function isSafeDocumentUri(uri: string): boolean {
   const scheme = uri.trim().toLowerCase()
@@ -72,7 +100,7 @@ function buildFactsheet(
 
   const text = (value: string): KeyFact['value'] => ({ kind: 'text', text: value })
 
-  const items: KeyFact[] = [
+  const keyFactItems: KeyFact[] = [
     { label: 'Issuer', value: text(issuer.name) },
     { label: 'Asset type', value: text(`${asset.class} - ${asset.subClass}`) },
     { label: 'APY', value: { kind: 'ref', ref: 'apy' } },
@@ -81,21 +109,46 @@ function buildFactsheet(
 
   const weightedAverageMaturity = firstShareClass?.weightedAverageMaturity
   if (weightedAverageMaturity != null) {
-    items.push({ label: 'Average asset maturity', value: text(`${weightedAverageMaturity} days`) })
+    keyFactItems.push({ label: 'Average asset maturity', value: text(`${weightedAverageMaturity} days`) })
   }
   if (expenseRatio != null && expenseRatio !== '') {
-    items.push({ label: 'Expense ratio', value: text(`${expenseRatio}%`) })
+    keyFactItems.push({ label: 'Expense ratio', value: text(`${expenseRatio}%`) })
   }
   const minInitialInvestment = firstShareClass?.minInitialInvestment
   if (minInitialInvestment != null) {
-    items.push({ label: 'Min. investment', value: text(formatMinInvestment(minInitialInvestment)) })
-  }
-  for (const category of issuer.categories) {
-    items.push({ label: category.type, value: text(category.value) })
+    keyFactItems.push({ label: 'Min. investment', value: text(formatMinInvestment(minInitialInvestment)) })
   }
 
-  // The right column is groups only; seed one untitled group holding the projected key facts.
-  const keyFacts: KeyFactGroup[] = [{ type: 'keyFactGroup', id: 'key-facts', items }]
+  // Issuer categories are split: known service-provider roles go into a "Service providers" group,
+  // everything else stays in "Key facts". Matching is case/separator-insensitive; an unknown type
+  // falls back to "Key facts" (the seed is ops-editable, so a miss is low-cost).
+  const serviceProviderItems: KeyFact[] = []
+  for (const category of issuer.categories) {
+    const label = SERVICE_PROVIDER_CATEGORIES.get(normalizeCategoryType(category.type))
+    if (label) {
+      serviceProviderItems.push({ label, value: text(category.value) })
+    } else {
+      keyFactItems.push({ label: category.type, value: text(category.value) })
+    }
+  }
+
+  // Ratings render via the `ratings` ref widget, reading the typed `poolRatings` field verbatim
+  // (agency/value/reportUrl/reportFile). The data is not duplicated into the key fact.
+  if ((poolRatings ?? []).length > 0) {
+    keyFactItems.push({ label: 'Ratings', value: { kind: 'ref', ref: 'ratings' } })
+  }
+
+  // The right column is groups only. Seed a titled "Key facts" group, plus a "Service providers"
+  // group when any category matched.
+  const keyFacts: KeyFactGroup[] = [{ type: 'keyFactGroup', id: 'key-facts', title: 'Key facts', items: keyFactItems }]
+  if (serviceProviderItems.length > 0) {
+    keyFacts.push({
+      type: 'keyFactGroup',
+      id: 'service-providers',
+      title: 'Service providers',
+      items: serviceProviderItems,
+    })
+  }
 
   const body: LayoutItem[] = []
   if (issuer.description) {
@@ -104,6 +157,8 @@ function buildFactsheet(
   ;(details ?? []).forEach((detail, index) => {
     body.push({ type: 'text', id: `detail-${index}`, title: detail.title, body: detail.body })
   })
+  // Ratings reports are surfaced two ways: a Documents body block (markdown links to the report
+  // PDFs) and the `ratings` key-fact ref pill above. Both read the same typed `poolRatings` field.
   const ratingsWithReports = (poolRatings ?? []).filter(
     (rating) => rating.reportFile?.uri && isSafeDocumentUri(rating.reportFile.uri)
   )
@@ -149,7 +204,8 @@ function buildFactsheet(
  * unit-testable. Returns the input unchanged when it is already v2.
  *
  * - Strips fields unused by every consumer (`newInvestmentsStatus`, `reports`, `loanTemplates`,
- *   `issuer.repName/shortDescription`, onboarding extras) and reshapes `issuer`/`poolRatings`.
+ *   `issuer.repName/shortDescription`, onboarding extras) and reshapes `issuer`. `poolRatings` is
+ *   preserved verbatim as a typed field (surfaced via the `ratings` key-fact ref).
  * - Maps legacy APY modes across `shareClasses[*].apy`.
  * - Projects the legacy display fields into `pool.factsheet`, and folds the off-chain `holdings`
  *   blob into a `table` section (`id: 'holdings'`); `holdings` is not carried as a top-level field.
@@ -174,8 +230,9 @@ export function migratePoolMetadataToV2(legacy: PoolMetadata): PoolMetadataV2 {
     pool: {
       ...restPool,
       issuer: { name: issuer.name, email: issuer.email, logo: issuer.logo },
-      poolRatings: poolRatings?.map(({ reportFile: _reportFile, ...rating }) => rating),
-      // Legacy `holdings` is folded into the factsheet here and not carried as a top-level field.
+      // `poolRatings` stays a typed field verbatim (incl. reportFile); surfaced via the `ratings`
+      // key-fact ref. `holdings` is folded into the factsheet and not carried as a top-level field.
+      poolRatings,
       factsheet: buildFactsheet(pool, shareClasses, holdings),
     },
     shareClasses: migratedShareClasses,
@@ -210,7 +267,7 @@ const DATA_REFS = new Set<DataRef>(['apyVsBenchmarks', 'maturityDistribution'])
 const SECTION_REFS = new Set<SectionRef>(['onchainMetrics', 'smartContracts'])
 const LIVE_METRICS = new Set<LiveMetric>(['tokenPrice', 'nav', 'apy30d', 'navChange', 'monthlyReturn'])
 const LIVE_DATASETS = new Set<LiveDataset>(['monthlySummary'])
-const KEY_FACT_REFS = new Set(['apy', 'availableNetworks'])
+const KEY_FACT_REFS = new Set(['apy', 'availableNetworks', 'ratings'])
 const COLUMN_FORMATS = new Set<ColumnFormat>(['text', 'number', 'percent', 'currency'])
 const CONTENT_BLOCK_TYPES = new Set(['text', 'table', 'chart', 'image', 'kpiGroup', 'tabGroup', 'liveTable'])
 const TAB_BLOCK_TYPES = new Set(['text', 'table', 'chart', 'kpiGroup'])

--- a/src/utils/poolMetadataMigration.ts
+++ b/src/utils/poolMetadataMigration.ts
@@ -53,25 +53,16 @@ function normalizeCategoryType(type: string): string {
 
 /**
  * Issuer-category `type` values (normalized) that migrate into the "Service providers" key-fact
- * group, mapped to their display label. Anything not listed stays in "Key facts". This is a seed
- * heuristic, not a validated registry: an unmatched type is simply left in "Key facts", so the list
- * is safe to extend. NOTE: confirm/extend this against the production category vocabulary.
+ * group, mapped to their display label. Anything not listed stays in "Key facts" (the seed is
+ * ops-editable, so an unmatched type is low-cost). Manager roles (portfolio/investment/asset
+ * manager) are intentionally NOT here; they stay in Key facts. `administrator` is an alias of
+ * Fund Administrator.
  */
 const SERVICE_PROVIDER_CATEGORIES = new Map<string, string>([
-  ['portfoliomanager', 'Portfolio Manager'],
-  ['investmentmanager', 'Investment Manager'],
-  ['assetmanager', 'Asset Manager'],
   ['custodian', 'Custodian'],
-  ['subcustodian', 'Sub-Custodian'],
-  ['administrator', 'Administrator'],
   ['fundadministrator', 'Fund Administrator'],
+  ['administrator', 'Fund Administrator'],
   ['auditor', 'Auditor'],
-  ['trustee', 'Trustee'],
-  ['transferagent', 'Transfer Agent'],
-  ['payingagent', 'Paying Agent'],
-  ['legalcounsel', 'Legal Counsel'],
-  ['legaladvisor', 'Legal Advisor'],
-  ['primebroker', 'Prime Broker'],
 ])
 
 /** Document links only carry web/IPFS URIs; anything else (e.g. `javascript:`) is dropped. */
@@ -131,6 +122,14 @@ function buildFactsheet(
       keyFactItems.push({ label: category.type, value: text(category.value) })
     }
   }
+
+  // Seeded for every migrated pool (app-derived, no v1 source): the wallet infrastructure icon and
+  // the live "available networks" ref. Both are ops-editable afterwards.
+  keyFactItems.push({
+    label: 'Wallet infrastructure',
+    value: { kind: 'icons', icons: [{ source: 'app', key: 'fordefi' }] },
+  })
+  keyFactItems.push({ label: 'Available networks', value: { kind: 'ref', ref: 'availableNetworks' } })
 
   // Ratings render via the `ratings` ref widget, reading the typed `poolRatings` field verbatim
   // (agency/value/reportUrl/reportFile). The data is not duplicated into the key fact.

--- a/src/utils/poolMetadataMigration.ts
+++ b/src/utils/poolMetadataMigration.ts
@@ -8,6 +8,7 @@ import {
   type Factsheet,
   isPoolMetadataV2,
   type KeyFact,
+  type KeyFactGroup,
   type LayoutItem,
   type LegacyApyMode,
   type LiveDataset,
@@ -69,27 +70,32 @@ function buildFactsheet(
   const { issuer, asset, poolStructure, expenseRatio, details, poolRatings } = pool
   const firstShareClass = Object.values(shareClasses)[0]
 
-  const keyFacts: KeyFact[] = [
-    { label: 'Issuer', value: issuer.name },
-    { label: 'Asset type', value: `${asset.class} - ${asset.subClass}` },
-    { label: 'APY', valueRef: 'apy' },
-    { label: 'Pool structure', value: poolStructure },
+  const text = (value: string): KeyFact['value'] => ({ kind: 'text', text: value })
+
+  const items: KeyFact[] = [
+    { label: 'Issuer', value: text(issuer.name) },
+    { label: 'Asset type', value: text(`${asset.class} - ${asset.subClass}`) },
+    { label: 'APY', value: { kind: 'ref', ref: 'apy' } },
+    { label: 'Pool structure', value: text(poolStructure) },
   ]
 
   const weightedAverageMaturity = firstShareClass?.weightedAverageMaturity
   if (weightedAverageMaturity != null) {
-    keyFacts.push({ label: 'Average asset maturity', value: `${weightedAverageMaturity} days` })
+    items.push({ label: 'Average asset maturity', value: text(`${weightedAverageMaturity} days`) })
   }
   if (expenseRatio != null && expenseRatio !== '') {
-    keyFacts.push({ label: 'Expense ratio', value: `${expenseRatio}%` })
+    items.push({ label: 'Expense ratio', value: text(`${expenseRatio}%`) })
   }
   const minInitialInvestment = firstShareClass?.minInitialInvestment
   if (minInitialInvestment != null) {
-    keyFacts.push({ label: 'Min. investment', value: formatMinInvestment(minInitialInvestment) })
+    items.push({ label: 'Min. investment', value: text(formatMinInvestment(minInitialInvestment)) })
   }
   for (const category of issuer.categories) {
-    keyFacts.push({ label: category.type, value: category.value })
+    items.push({ label: category.type, value: text(category.value) })
   }
+
+  // The right column is groups only; seed one untitled group holding the projected key facts.
+  const keyFacts: KeyFactGroup[] = [{ type: 'keyFactGroup', id: 'key-facts', items }]
 
   const body: LayoutItem[] = []
   if (issuer.description) {
@@ -204,6 +210,7 @@ const DATA_REFS = new Set<DataRef>(['apyVsBenchmarks', 'maturityDistribution'])
 const SECTION_REFS = new Set<SectionRef>(['onchainMetrics', 'smartContracts'])
 const LIVE_METRICS = new Set<LiveMetric>(['tokenPrice', 'nav', 'apy30d', 'navChange', 'monthlyReturn'])
 const LIVE_DATASETS = new Set<LiveDataset>(['monthlySummary'])
+const KEY_FACT_REFS = new Set(['apy', 'availableNetworks'])
 const COLUMN_FORMATS = new Set<ColumnFormat>(['text', 'number', 'percent', 'currency'])
 const CONTENT_BLOCK_TYPES = new Set(['text', 'table', 'chart', 'image', 'kpiGroup', 'tabGroup', 'liveTable'])
 const TAB_BLOCK_TYPES = new Set(['text', 'table', 'chart', 'kpiGroup'])
@@ -238,14 +245,61 @@ function validateFile(value: unknown, where: string): void {
   assertString(value.mime, `${where}.mime`)
 }
 
+function validateIconRef(value: unknown, where: string): void {
+  if (!isObject(value)) fail(`${where} must be an object`)
+  if (value.label !== undefined) assertString(value.label, `${where}.label`)
+  switch (value.source) {
+    case 'metadata':
+      validateFile(value.file, `${where}.file`)
+      if (value.alt !== undefined) assertString(value.alt, `${where}.alt`)
+      break
+    case 'app':
+      // The app-owned icon-key registry is not yet enumerated, so validate shape (string) only.
+      assertString(value.key, `${where}.key`)
+      break
+    default:
+      fail(`${where} has an invalid source "${String(value.source)}"`)
+  }
+}
+
+function validateKeyFactValue(value: unknown, where: string): void {
+  if (!isObject(value)) fail(`${where} must be an object`)
+  switch (value.kind) {
+    case 'text':
+      assertString(value.text, `${where}.text`)
+      break
+    case 'icons':
+      if (!Array.isArray(value.icons)) fail(`${where}.icons must be an array`)
+      value.icons.forEach((icon, index) => validateIconRef(icon, `${where}.icons[${index}]`))
+      break
+    case 'ref':
+      // Closed, SDK-enforced registry (extended via a coordinated SDK release).
+      if (typeof value.ref !== 'string' || !KEY_FACT_REFS.has(value.ref)) {
+        fail(`${where}.ref is invalid (unknown ref "${String(value.ref)}")`)
+      }
+      break
+    default:
+      fail(`${where} has an invalid kind "${String(value.kind)}"`)
+  }
+}
+
 function validateKeyFact(value: unknown, where: string): void {
   if (!isObject(value)) fail(`${where} must be an object`)
   assertString(value.label, `${where}.label`)
-  if (value.value !== undefined) assertString(value.value, `${where}.value`)
-  if (value.valueRef !== undefined && value.valueRef !== 'apy') fail(`${where}.valueRef must be 'apy'`)
+  validateKeyFactValue(value.value, `${where}.value`)
   if (value.tooltip !== undefined) assertString(value.tooltip, `${where}.tooltip`)
   if (value.href !== undefined) assertString(value.href, `${where}.href`)
   assertVisibility(value.visibility, where)
+}
+
+function validateKeyFactGroup(value: unknown, where: string): void {
+  if (!isObject(value)) fail(`${where} must be an object`)
+  if (value.type !== 'keyFactGroup') fail(`${where}.type must be 'keyFactGroup'`)
+  assertString(value.id, `${where}.id`)
+  if (value.title !== undefined) assertString(value.title, `${where}.title`)
+  assertVisibility(value.visibility, where)
+  if (!Array.isArray(value.items)) fail(`${where}.items must be an array`)
+  value.items.forEach((item, index) => validateKeyFact(item, `${where}.items[${index}]`))
 }
 
 function validateChartSeries(value: unknown, where: string): void {
@@ -315,15 +369,21 @@ function validateContentBlock(block: Record<string, unknown>, type: string, wher
       if (typeof block.chartType !== 'string' || !CHART_TYPES.has(block.chartType as ChartType)) {
         fail(`${where}.chartType is invalid`)
       }
-      const hasSeries = block.series !== undefined
-      const hasDataRef = block.dataRef !== undefined
-      if (hasSeries === hasDataRef) fail(`${where} must set exactly one of \`series\` or \`dataRef\``)
-      if (hasSeries) {
-        if (!Array.isArray(block.series)) fail(`${where}.series must be an array`)
-        block.series.forEach((s, index) => validateChartSeries(s, `${where}.series[${index}]`))
-      }
-      if (hasDataRef && (typeof block.dataRef !== 'string' || !DATA_REFS.has(block.dataRef as DataRef))) {
-        fail(`${where}.dataRef is invalid (unknown key "${String(block.dataRef)}")`)
+      // Data source is a single discriminated `data` (inline series XOR app/indexer dataRef).
+      if (!isObject(block.data)) fail(`${where}.data must be an object`)
+      switch (block.data.kind) {
+        case 'inline':
+          if (!Array.isArray(block.data.series)) fail(`${where}.data.series must be an array`)
+          block.data.series.forEach((s, index) => validateChartSeries(s, `${where}.data.series[${index}]`))
+          break
+        case 'ref':
+          // Closed, SDK-enforced registry (extended via a coordinated SDK release).
+          if (typeof block.data.dataRef !== 'string' || !DATA_REFS.has(block.data.dataRef as DataRef)) {
+            fail(`${where}.data.dataRef is invalid (unknown key "${String(block.data.dataRef)}")`)
+          }
+          break
+        default:
+          fail(`${where}.data has an invalid kind "${String(block.data.kind)}"`)
       }
       if (isObject(block.xAxis) && block.xAxis.type !== undefined && !XAXIS_TYPES.has(block.xAxis.type as string)) {
         fail(`${where}.xAxis.type is invalid`)
@@ -407,7 +467,7 @@ function validateFactsheet(factsheet: unknown): void {
   if (!Array.isArray(factsheet.body)) fail('`pool.factsheet.body` must be an array')
   factsheet.body.forEach((item, index) => validateLayoutItem(item, `pool.factsheet.body[${index}]`))
   if (!Array.isArray(factsheet.keyFacts)) fail('`pool.factsheet.keyFacts` must be an array')
-  factsheet.keyFacts.forEach((item, index) => validateKeyFact(item, `pool.factsheet.keyFacts[${index}]`))
+  factsheet.keyFacts.forEach((group, index) => validateKeyFactGroup(group, `pool.factsheet.keyFacts[${index}]`))
   if (factsheet.sections !== undefined) {
     if (!Array.isArray(factsheet.sections)) fail('`pool.factsheet.sections` must be an array')
     factsheet.sections.forEach((item, index) => validateLayoutItem(item, `pool.factsheet.sections[${index}]`))


### PR DESCRIPTION
## Summary

Two coordinated v2 pool-metadata changes for the 1.17.0 release:

1. **Fold legacy off-chain `holdings` into the factsheet** as a `table` section (closes the holdings follow-up).
2. **Implement centrifuge/sdk#480**: additive factsheet right-column delta (key-fact groups, icons, `availableNetworks`) plus a discriminated chart data source.

Registry governance from #478 is preserved: app-owned registries stay **closed and rejected on write** (the SDK is the alignment point). See the note at the bottom on where this diverges from #480 as originally written.

## 1. Holdings → factsheet table

- `migratePoolMetadataToV2` converts a legacy `holdings` `{ headers, data }` blob into a `table` block (`id: 'holdings'`, `title: 'Holdings'`) appended to `pool.factsheet.sections`. Faithful (no column dropped, e.g. ISIN); `number → number`, `null/undefined → ''`, else `String(value)`. Skipped when `headers` is empty or `data` is missing. Idempotent (an already-v2 doc has no `holdings` key).
- `holdings` removed from `PoolMetadataV2` and `PoolMetadataInput`; `PoolMetadataV1` keeps it so legacy docs still parse as v1. `Pool.update()` holdings mapping dropped.

## 2. #480 — factsheet right column + chart data

New / changed types (`src/types/poolMetadata.ts`, additive to v2):

- `IconRef` = `{ source:'metadata'; file; alt?; label? } | { source:'app'; key; label? }`.
- `KeyFactValue` discriminated by `kind`: `text` | `icons` | `ref` (`'apy' | 'availableNetworks'`). Replaces the old `value?` / `valueRef?` pair (removes the precedence ambiguity).
- `KeyFact.value` is now a single `KeyFactValue`.
- `KeyFactGroup` (`type: 'keyFactGroup'`); `Factsheet.keyFacts` is now `KeyFactGroup[]` (groups only, no bare key facts, no flat-`KeyFact[]` back-compat).
- `ChartData` = `{ kind:'inline'; series } | { kind:'ref'; dataRef }`; the `chart` block now has a single required `data`, replacing the optional `series?` / `dataRef?` pair (same "which field wins" smell removed from `KeyFact`).

Validation (`parsePoolMetadataV2`) validates all the new shapes. The `KeyFactValue` `ref` set and the chart `data.ref` `dataRef` are **closed sets, rejected on write**, consistent with the other registries (`DataRef`, `LiveMetric`, `LiveDataset`, `SectionRef`). The migration seeds `keyFacts` as one untitled `KeyFactGroup` of discriminated values.

## ⚠️ Breaking changes (1.17.0)

- `holdings` removed from `PoolMetadataV2` / `PoolMetadataInput` (folded into a `table` section by migration).
- `KeyFact.value` shape changed to discriminated `KeyFactValue`.
- `Factsheet.keyFacts` is now `KeyFactGroup[]` (was `KeyFact[]`).
- `chart` block: `series?`/`dataRef?` replaced by required `data: ChartData`.

Reads of legacy (v1) documents are unaffected. Downstream (apps-v3 management app, invest app) move to the new shapes: holdings from `metadata.holdings` to the holdings `table` block; right-column to `KeyFactGroup[]` / `KeyFactValue`; chart to `data`.

## Divergence from #480 as written (needs the issue updated)

#480 part (b) asks for **lenient** registry validation (tolerate unknown keys, never throw, no SDK release to add a key). Per the #478 decision, this PR instead keeps registries **closed and rejected on write** so the management app, SDK, and invest app must align. Issue #480's (b) and its title/deliverables should be updated to match (separate edit). Open point: the `IconRef.source:'app'` icon-key registry is not enumerated in #480, so it is shape-validated (string) here until a canonical set is defined.

## Test status

`pnpm build` green; `pnpm test:unit` green (228) incl. holdings + #480 validator/migration tests; `eslint` clean. Full Tenderly suite (`pnpm test`) is gated on `TENDERLY_ACCESS_KEY`, not run here.

## Shared SDK contract

Guards (`isPoolMetadataV2`, `isLegacyPoolMetadata`), `migratePoolMetadataToV2`, `parsePoolMetadataV2`, `Pool.migrateMetadata`, the section/visibility types, and the closed-registry-on-write rule are unchanged in spirit; the breaking shape changes above are the #480/holdings deltas.

Ref: centrifuge/apps-invest#200, closes centrifuge/sdk#480
