### PR TITLE
feat(poolMetadata): composable visibility gates, geo-restrictions, documents & accordion blocks, overview-card fields (#482)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@centrifuge/sdk",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "description": "",
   "homepage": "https://github.com/centrifuge/sdk/tree/main#readme",
   "author": "",

--- a/src/Centrifuge.ts
+++ b/src/Centrifuge.ts
@@ -271,6 +271,7 @@ export class Centrifuge {
             executiveSummary: metadataInput.executiveSummary,
             forum: metadataInput.forum,
             website: metadataInput.website,
+            ...(metadataInput.linkDocuments ? { documents: metadataInput.linkDocuments } : {}),
           },
           status: 'open',
           listed: metadataInput.listed ?? true,

--- a/src/entities/Pool.ts
+++ b/src/entities/Pool.ts
@@ -784,6 +784,7 @@ export class Pool extends Entity {
               executiveSummary: metadataInput?.executiveSummary ?? baseMetadata.pool.links?.executiveSummary,
               forum: metadataInput?.forum ?? baseMetadata.pool.links?.forum,
               website: metadataInput?.website ?? baseMetadata.pool.links?.website,
+              documents: metadataInput?.linkDocuments ?? baseMetadata.pool.links?.documents,
             },
             status: poolStatus,
             listed: metadataInput?.listed ?? baseMetadata.pool.listed,

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ export type {
 } from './types/workflow.js'
 export { runtimeVariableName } from './types/workflow.js'
 export * from './types/poolMetadata.js'
-export { migratePoolMetadataToV2, parsePoolMetadataV2 } from './utils/poolMetadataMigration.js'
+export { migratePoolMetadataToV2, parsePoolMetadataV2, resolveLinkTarget } from './utils/poolMetadataMigration.js'
 export type { Query } from './types/query.js'
 export type {
   DeployedOnchainPMStatus,

--- a/src/tests/mocks/mockPoolMetadataV2.ts
+++ b/src/tests/mocks/mockPoolMetadataV2.ts
@@ -31,6 +31,10 @@ export const mockPoolMetadataV2: PoolMetadataV2 = {
       },
       forum: 'https://gov.centrifuge.io/tag/newsilver',
       website: 'https://newsilver.com',
+      documents: [
+        { key: 'prospectus', label: 'Prospectus', file: { uri: 'ipfs://QmProspectusDoc', mime: 'application/pdf' } },
+        { key: 'termsOfService', label: 'Terms of Service', href: 'https://example.com/tos' },
+      ],
     },
     status: 'open',
     listed: true,

--- a/src/tests/mocks/mockPoolMetadataV2.ts
+++ b/src/tests/mocks/mockPoolMetadataV2.ts
@@ -52,7 +52,7 @@ export const mockPoolMetadataV2: PoolMetadataV2 = {
         reportFile: { uri: 'ipfs://QmRatingReport', mime: 'application/pdf' },
       },
     ],
-    geoBlock: { regions: ['US', 'KP'] },
+    geoRestrictions: { regions: ['US', 'KP'] },
     factsheet: {
       keyFacts: [
         {
@@ -82,6 +82,12 @@ export const mockPoolMetadataV2: PoolMetadataV2 = {
               },
             },
             { label: 'Secret fact', value: { kind: 'text', text: 'hidden value' }, visibility: 'whitelisted' },
+            // Combined gates: shown only to a whitelisted wallet in an allowed region.
+            {
+              label: 'Restricted yield',
+              value: { kind: 'text', text: '12%' },
+              visibility: ['whitelisted', 'geo-restricted'],
+            },
           ],
         },
       ],
@@ -211,8 +217,8 @@ export const mockPoolMetadataV2: PoolMetadataV2 = {
           type: 'text',
           id: 'geo-note',
           title: 'Regional note',
-          body: 'Shown only outside blocked regions.',
-          visibility: 'geo-blocked',
+          body: 'Shown only outside restricted regions.',
+          visibility: 'geo-restricted',
         },
         { type: 'section', id: 'performance', ref: 'onchainMetrics' },
       ],

--- a/src/tests/mocks/mockPoolMetadataV2.ts
+++ b/src/tests/mocks/mockPoolMetadataV2.ts
@@ -52,6 +52,7 @@ export const mockPoolMetadataV2: PoolMetadataV2 = {
         reportFile: { uri: 'ipfs://QmRatingReport', mime: 'application/pdf' },
       },
     ],
+    geoBlock: { regions: ['US', 'KP'] },
     factsheet: {
       keyFacts: [
         {
@@ -85,7 +86,18 @@ export const mockPoolMetadataV2: PoolMetadataV2 = {
         },
       ],
       body: [
-        { type: 'text', id: 'overview', title: 'Overview', body: 'Fake **overview** with a [link](https://x.io).' },
+        {
+          type: 'text',
+          id: 'overview',
+          title: 'Overview',
+          body: 'Fake **overview** with a [link](https://x.io).',
+          logo: { uri: 'ipfs://QmBrandLogo', mime: 'image/svg+xml' },
+          background: '#0b1f3a',
+          links: [
+            { label: 'Factsheet', target: { kind: 'linkRef', linkRef: 'executiveSummary' } },
+            { label: 'Website', target: { kind: 'href', href: 'https://newsilver.com' } },
+          ],
+        },
         {
           type: 'table',
           id: 'fees',
@@ -165,6 +177,42 @@ export const mockPoolMetadataV2: PoolMetadataV2 = {
             { header: 'Note', source: 'hardcoded', key: 'note' },
           ],
           caption: 'Recent months',
+        },
+        {
+          type: 'documents',
+          id: 'docs',
+          title: 'Documents',
+          items: [
+            { title: 'Fact Sheet', target: { kind: 'linkRef', linkRef: 'executiveSummary' } },
+            {
+              title: 'Prospectus',
+              target: { kind: 'file', file: { uri: 'ipfs://QmProspectus', mime: 'application/pdf' } },
+            },
+            { title: 'Terms', target: { kind: 'href', href: 'https://example.com/terms' } },
+          ],
+        },
+        {
+          type: 'accordion',
+          id: 'details-accordion',
+          title: 'Details',
+          items: [
+            {
+              title: 'Overview',
+              defaultOpen: true,
+              block: { type: 'text', id: 'acc-overview', body: 'Accordion text.' },
+            },
+            {
+              title: 'Characteristics',
+              block: { type: 'kpiGroup', id: 'acc-kpis', items: [{ label: 'Duration', value: '0.2y' }] },
+            },
+          ],
+        },
+        {
+          type: 'text',
+          id: 'geo-note',
+          title: 'Regional note',
+          body: 'Shown only outside blocked regions.',
+          visibility: 'geo-blocked',
         },
         { type: 'section', id: 'performance', ref: 'onchainMetrics' },
       ],

--- a/src/types/poolInput.ts
+++ b/src/types/poolInput.ts
@@ -1,5 +1,5 @@
 import { HexString } from './index.js'
-import type { ApyMode, Factsheet, LegacyApyMode, PoolMetadata } from './poolMetadata.js'
+import type { ApyMode, Factsheet, LegacyApyMode, LinkDocument, PoolMetadata } from './poolMetadata.js'
 
 export type FileType = { uri: string; mime: string }
 
@@ -46,6 +46,8 @@ export type PoolMetadataInput = {
   forum: string
   email: string
   executiveSummary: FileType | null
+  /** Reusable named documents written to `pool.links.documents` (referenceable via `linkRef`). */
+  linkDocuments?: LinkDocument[]
   /**
    * @deprecated v2 has no flat `details`; author them via `factsheet` `text` blocks. Ignored by
    * `createPool`/`update`.

--- a/src/types/poolMetadata.ts
+++ b/src/types/poolMetadata.ts
@@ -265,18 +265,25 @@ export type WithdrawManager = {
  * ---------------------------------------------------------------------------------------------- */
 
 /**
- * Access gating for any block, key fact, column, or kpi item. Default `'public'`. Resolved app-side
- * against the connected wallet's share-class (transfer-hook) membership. Presentational only — never
- * a substitute for on-chain access control.
- * - `public`      — rendered for everyone.
- * - `whitelisted` — full content only for a whitelisted wallet; otherwise blurred behind an
- *                   app-owned overlay that keeps its layout footprint (no reflow on connect).
- * - `geo-blocked` — gated when the user's region is in `pool.geoBlock.regions`. Like `whitelisted`,
- *                   presentational only and resolved app-side. With no `pool.geoBlock` list, nothing
- *                   is blocked (effectively `public`).
- * - `hidden`      — never rendered, for anyone (not laid out).
+ * A single audience gate applied to an element. Presentational only, resolved app-side; never a
+ * substitute for on-chain / compliance access control.
+ * - `whitelisted`    — passes only for a wallet in the share class's transfer-hook allowlist;
+ *                      otherwise blurred behind an app-owned overlay that keeps its layout footprint.
+ * - `geo-restricted` — passes only when the user's region is NOT in `pool.geoRestrictions.regions`
+ *                      (with no such list, nothing is restricted).
  */
-export type Visibility = 'public' | 'whitelisted' | 'geo-blocked' | 'hidden'
+export type VisibilityGate = 'whitelisted' | 'geo-restricted'
+
+/**
+ * Access gating for any block, key fact, column, or kpi item. Default `'public'`.
+ * - `'public'` (or absent) — rendered for everyone.
+ * - `'hidden'`             — never rendered, for anyone (not laid out).
+ * - a single {@link VisibilityGate} or an **array of gates** — rendered only when ALL listed gates
+ *   pass (AND). e.g. `['whitelisted', 'geo-restricted']` = a whitelisted wallet in an allowed
+ *   region. `'public'`/`'hidden'` may not appear inside the array. When several gates fail, the app
+ *   shows the most restrictive overlay (geo before whitelist).
+ */
+export type Visibility = 'public' | 'hidden' | VisibilityGate | VisibilityGate[]
 
 /**
  * Constrained Markdown subset (paragraphs, hard newlines, `-`/`*` and `1.` lists, `**bold**`,
@@ -549,10 +556,10 @@ export type PoolMetadataV2 = {
     poolRatings?: PoolRatingV2[]
     factsheet?: Factsheet
     /**
-     * Single pool-level blocked-regions list (ISO 3166-1 alpha-2 codes, e.g. `'US'`). Every
-     * `geo-blocked` element is gated against it. Presentational only; not compliance/access control.
+     * Single pool-level restricted-regions list (ISO 3166-1 alpha-2 codes, e.g. `'US'`). Every
+     * `geo-restricted` element is gated against it. Presentational only; not compliance/access control.
      */
-    geoBlock?: { regions: string[] }
+    geoRestrictions?: { regions: string[] }
   }
   shareClasses: PoolMetadataV1['shareClasses']
   merkleProofManager?: PoolMetadataV1['merkleProofManager']

--- a/src/types/poolMetadata.ts
+++ b/src/types/poolMetadata.ts
@@ -162,6 +162,11 @@ export type PoolMetadataV1 = {
       executiveSummary: FileType | null
       forum?: string
       website?: string
+      /**
+       * Reusable named documents authored once and referenced anywhere in the factsheet via a
+       * {@link LinkTarget} `{ kind: 'linkRef', linkRef: key }`. See {@link LinkDocument}.
+       */
+      documents?: LinkDocument[]
     }
     details?: {
       title: string
@@ -401,6 +406,18 @@ export type LinkTarget =
   | { kind: 'file'; file: FileType }
   | { kind: 'href'; href: string }
   | { kind: 'linkRef'; linkRef: string }
+
+/**
+ * A reusable named document on `pool.links.documents`, referenced from a {@link LinkTarget} via
+ * `{ kind: 'linkRef', linkRef: key }`. Carries exactly one of `file` or `href`.
+ */
+export type LinkDocument = {
+  /** Unique slug a `linkRef` points at; must not collide with `executiveSummary`/`website`/`forum`. */
+  key: string
+  label: string
+  file?: FileType | null
+  href?: string
+}
 
 export type TextBlock = BlockBase & {
   type: 'text'

--- a/src/types/poolMetadata.ts
+++ b/src/types/poolMetadata.ts
@@ -271,9 +271,12 @@ export type WithdrawManager = {
  * - `public`      — rendered for everyone.
  * - `whitelisted` — full content only for a whitelisted wallet; otherwise blurred behind an
  *                   app-owned overlay that keeps its layout footprint (no reflow on connect).
+ * - `geo-blocked` — gated when the user's region is in `pool.geoBlock.regions`. Like `whitelisted`,
+ *                   presentational only and resolved app-side. With no `pool.geoBlock` list, nothing
+ *                   is blocked (effectively `public`).
  * - `hidden`      — never rendered, for anyone (not laid out).
  */
-export type Visibility = 'public' | 'whitelisted' | 'hidden'
+export type Visibility = 'public' | 'whitelisted' | 'geo-blocked' | 'hidden'
 
 /**
  * Constrained Markdown subset (paragraphs, hard newlines, `-`/`*` and `1.` lists, `**bold**`,
@@ -379,7 +382,28 @@ export type KeyFactGroup = {
 
 type BlockBase = { id: string; title?: string; visibility?: Visibility }
 
-export type TextBlock = BlockBase & { type: 'text'; body: RichText }
+/**
+ * A single link destination, discriminated by `kind` (no competing-optional ambiguity):
+ * - `file`    — an inline IPFS asset.
+ * - `href`    — an inline URL.
+ * - `linkRef` — a key in the typed `pool.links` (e.g. `'executiveSummary'`, `'website'`), so the
+ *               URL/file has a single source of truth. The app resolves it; an unknown key hides
+ *               the tile/button (graceful read).
+ */
+export type LinkTarget =
+  | { kind: 'file'; file: FileType }
+  | { kind: 'href'; href: string }
+  | { kind: 'linkRef'; linkRef: string }
+
+export type TextBlock = BlockBase & {
+  type: 'text'
+  body: RichText
+  /** Overview-card extras (all optional): a brand logo, a card background, and link buttons. */
+  logo?: FileType
+  /** Theme token or hex color for the card background. */
+  background?: string
+  links?: Array<{ label: string; target: LinkTarget }>
+}
 
 export type TableBlock = BlockBase & {
   type: 'table'
@@ -453,6 +477,18 @@ export type TabGroupBlock = BlockBase & {
   tabs: Array<{ label: string; block: TabBlock }>
 }
 
+/** A tile list (doc icon + title) opening each item's {@link LinkTarget}, e.g. a "Fact Sheet" tile. */
+export type DocumentsBlock = BlockBase & {
+  type: 'documents'
+  items: Array<{ title: string; target: LinkTarget }>
+}
+
+/** A collapsible stack (accordion UX). Each item holds a {@link TabBlock} leaf, like `tabGroup` tabs. */
+export type AccordionBlock = BlockBase & {
+  type: 'accordion'
+  items: Array<{ title: string; block: TabBlock; defaultOpen?: boolean }>
+}
+
 export type ContentBlock =
   | TextBlock
   | TableBlock
@@ -461,6 +497,8 @@ export type ContentBlock =
   | KpiGroupBlock
   | TabGroupBlock
   | LiveTableBlock
+  | DocumentsBlock
+  | AccordionBlock
 
 /** A pointer to one of the closed, app-owned section units. */
 export type SectionRefBlock = {
@@ -510,6 +548,11 @@ export type PoolMetadataV2 = {
     issuer: Pick<PoolMetadataV1['pool']['issuer'], 'name' | 'email' | 'logo'>
     poolRatings?: PoolRatingV2[]
     factsheet?: Factsheet
+    /**
+     * Single pool-level blocked-regions list (ISO 3166-1 alpha-2 codes, e.g. `'US'`). Every
+     * `geo-blocked` element is gated against it. Presentational only; not compliance/access control.
+     */
+    geoBlock?: { regions: string[] }
   }
   shareClasses: PoolMetadataV1['shareClasses']
   merkleProofManager?: PoolMetadataV1['merkleProofManager']

--- a/src/utils/poolMetadataMigration.test.ts
+++ b/src/utils/poolMetadataMigration.test.ts
@@ -578,28 +578,46 @@ describe('parsePoolMetadataV2', () => {
     expect(() => parsePoolMetadataV2(bad)).to.throw(/keyFacts\[0\].items must be an array/)
   })
 
-  // --- #482: geo-block, documents/accordion blocks, link targets ---
+  // --- #482: geo-restrictions, documents/accordion blocks, link targets, combined visibility ---
 
-  it('accepts geo-blocked visibility and a valid geoBlock list', () => {
+  it('accepts geo-restricted visibility (single + combined) and a valid geoRestrictions list', () => {
     expect(() => parsePoolMetadataV2(mockPoolMetadataV2)).to.not.throw()
   })
 
-  it('accepts geo-blocked elements even when pool.geoBlock is absent (nothing blocked)', () => {
+  it('accepts geo-restricted elements even when pool.geoRestrictions is absent (nothing restricted)', () => {
     const doc = clone(mockPoolMetadataV2)
-    delete (doc.pool as Record<string, unknown>).geoBlock
+    delete (doc.pool as Record<string, unknown>).geoRestrictions
     expect(() => parsePoolMetadataV2(doc)).to.not.throw()
   })
 
-  it('rejects geoBlock regions that are not ISO 3166-1 alpha-2', () => {
+  it('rejects geoRestrictions regions that are not ISO 3166-1 alpha-2', () => {
     const bad = clone(mockPoolMetadataV2)
-    bad.pool.geoBlock = { regions: ['US', 'USA'] }
-    expect(() => parsePoolMetadataV2(bad)).to.throw(/geoBlock.regions\[1\] must be an ISO 3166-1 alpha-2 code/)
+    bad.pool.geoRestrictions = { regions: ['US', 'USA'] }
+    expect(() => parsePoolMetadataV2(bad)).to.throw(/geoRestrictions.regions\[1\] must be an ISO 3166-1 alpha-2 code/)
   })
 
-  it('rejects an invalid visibility (the union is still closed)', () => {
+  it('rejects an invalid visibility scalar', () => {
     const bad = clone(mockPoolMetadataV2)
     bad.pool.factsheet!.keyFacts[0]!.visibility = 'continent-blocked' as never
     expect(() => parsePoolMetadataV2(bad)).to.throw(/visibility/)
+  })
+
+  it('rejects a visibility array containing a non-gate (public/hidden or unknown)', () => {
+    const bad = clone(mockPoolMetadataV2)
+    bad.pool.factsheet!.keyFacts[0]!.visibility = ['whitelisted', 'public'] as never
+    expect(() => parsePoolMetadataV2(bad)).to.throw(/invalid visibility gate/)
+  })
+
+  it('rejects a visibility array with duplicate gates', () => {
+    const bad = clone(mockPoolMetadataV2)
+    bad.pool.factsheet!.keyFacts[0]!.visibility = ['whitelisted', 'whitelisted'] as never
+    expect(() => parsePoolMetadataV2(bad)).to.throw(/duplicate visibility gate/)
+  })
+
+  it('rejects an empty visibility array', () => {
+    const bad = clone(mockPoolMetadataV2)
+    bad.pool.factsheet!.keyFacts[0]!.visibility = [] as never
+    expect(() => parsePoolMetadataV2(bad)).to.throw(/visibility array must not be empty/)
   })
 
   it('rejects a link target with an unknown kind', () => {

--- a/src/utils/poolMetadataMigration.test.ts
+++ b/src/utils/poolMetadataMigration.test.ts
@@ -241,6 +241,34 @@ describe('migratePoolMetadataToV2', () => {
     ])
   })
 
+  it('builds the Overview card with logo and a Factsheet linkRef when those source fields exist', () => {
+    const legacy = legacyFixture()
+    legacy.pool.issuer.logo = { uri: 'ipfs://QmLogo', mime: 'image/png' }
+    legacy.pool.links = { executiveSummary: { uri: 'ipfs://QmFactsheet', mime: 'application/pdf' } }
+    const overview = migratePoolMetadataToV2(legacy).pool.factsheet!.body.find((b) => b.id === 'overview')
+    expect(overview).to.deep.equal({
+      type: 'text',
+      id: 'overview',
+      title: 'Overview',
+      body: 'A long issuer description.',
+      logo: { uri: 'ipfs://QmLogo', mime: 'image/png' },
+      links: [{ label: 'Factsheet', target: { kind: 'linkRef', linkRef: 'executiveSummary' } }],
+    })
+  })
+
+  it('omits the Overview logo and Factsheet link when their source fields are absent/empty', () => {
+    const legacy = legacyFixture()
+    legacy.pool.issuer.logo = { uri: '', mime: 'image/png' } // empty uri => treated as absent
+    legacy.pool.links = { executiveSummary: null }
+    const overview = migratePoolMetadataToV2(legacy).pool.factsheet!.body.find((b) => b.id === 'overview')
+    expect(overview).to.deep.equal({
+      type: 'text',
+      id: 'overview',
+      title: 'Overview',
+      body: 'A long issuer description.',
+    })
+  })
+
   it('drops unsafe document URI schemes and escapes the rating label', () => {
     const legacy = legacyFixture()
     legacy.pool.poolRatings = [
@@ -536,5 +564,70 @@ describe('parsePoolMetadataV2', () => {
     const bad = clone(mockPoolMetadataV2)
     delete (bad.pool.factsheet!.keyFacts[0] as Record<string, unknown>).items
     expect(() => parsePoolMetadataV2(bad)).to.throw(/keyFacts\[0\].items must be an array/)
+  })
+
+  // --- #482: geo-block, documents/accordion blocks, link targets ---
+
+  it('accepts geo-blocked visibility and a valid geoBlock list', () => {
+    expect(() => parsePoolMetadataV2(mockPoolMetadataV2)).to.not.throw()
+  })
+
+  it('accepts geo-blocked elements even when pool.geoBlock is absent (nothing blocked)', () => {
+    const doc = clone(mockPoolMetadataV2)
+    delete (doc.pool as Record<string, unknown>).geoBlock
+    expect(() => parsePoolMetadataV2(doc)).to.not.throw()
+  })
+
+  it('rejects geoBlock regions that are not ISO 3166-1 alpha-2', () => {
+    const bad = clone(mockPoolMetadataV2)
+    bad.pool.geoBlock = { regions: ['US', 'USA'] }
+    expect(() => parsePoolMetadataV2(bad)).to.throw(/geoBlock.regions\[1\] must be an ISO 3166-1 alpha-2 code/)
+  })
+
+  it('rejects an invalid visibility (the union is still closed)', () => {
+    const bad = clone(mockPoolMetadataV2)
+    bad.pool.factsheet!.keyFacts[0]!.visibility = 'continent-blocked' as never
+    expect(() => parsePoolMetadataV2(bad)).to.throw(/visibility/)
+  })
+
+  it('rejects a link target with an unknown kind', () => {
+    const bad = clone(mockPoolMetadataV2)
+    const docs = bad.pool.factsheet!.body.find((b) => b.id === 'docs') as { items: Record<string, unknown>[] }
+    docs.items[0]!.target = { kind: 'mailto', mailto: 'x@y.z' }
+    expect(() => parsePoolMetadataV2(bad)).to.throw(/target has an invalid kind/)
+  })
+
+  it('rejects a documents item missing its target', () => {
+    const bad = clone(mockPoolMetadataV2)
+    const docs = bad.pool.factsheet!.body.find((b) => b.id === 'docs') as { items: Record<string, unknown>[] }
+    delete docs.items[0]!.target
+    expect(() => parsePoolMetadataV2(bad)).to.throw(/items\[0\].target must be an object/)
+  })
+
+  it('rejects an accordion item whose inner block is not a leaf type', () => {
+    const bad = clone(mockPoolMetadataV2)
+    const accordion = bad.pool.factsheet!.body.find((b) => b.id === 'details-accordion') as {
+      items: { block: Record<string, unknown> }[]
+    }
+    accordion.items[0]!.block = { type: 'documents', id: 'nope', items: [] }
+    expect(() => parsePoolMetadataV2(bad)).to.throw(/block has an invalid type/)
+  })
+
+  it('rejects an accordion item with a non-boolean defaultOpen', () => {
+    const bad = clone(mockPoolMetadataV2)
+    const accordion = bad.pool.factsheet!.body.find((b) => b.id === 'details-accordion') as {
+      items: Record<string, unknown>[]
+    }
+    accordion.items[0]!.defaultOpen = 'yes'
+    expect(() => parsePoolMetadataV2(bad)).to.throw(/defaultOpen must be a boolean/)
+  })
+
+  it('rejects an overview text-block link with a malformed target', () => {
+    const bad = clone(mockPoolMetadataV2)
+    const overview = bad.pool.factsheet!.body.find((b) => b.id === 'overview') as {
+      links: { target: unknown }[]
+    }
+    overview.links[0]!.target = { kind: 'linkRef' } // missing linkRef string
+    expect(() => parsePoolMetadataV2(bad)).to.throw(/linkRef must be a string/)
   })
 })

--- a/src/utils/poolMetadataMigration.test.ts
+++ b/src/utils/poolMetadataMigration.test.ts
@@ -3,7 +3,7 @@ import { mockPoolMetadata } from '../tests/mocks/mockPoolMetadata.js'
 import { mockPoolMetadataV2 } from '../tests/mocks/mockPoolMetadataV2.js'
 import type { PoolMetadataV1, PoolMetadataV2 } from '../types/poolMetadata.js'
 import { isPoolMetadataV2 } from '../types/poolMetadata.js'
-import { migratePoolMetadataToV2, parsePoolMetadataV2 } from './poolMetadataMigration.js'
+import { migratePoolMetadataToV2, parsePoolMetadataV2, resolveLinkTarget } from './poolMetadataMigration.js'
 
 const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T
 
@@ -117,6 +117,16 @@ describe('migratePoolMetadataToV2', () => {
         { assetAddress: '0xa0b8', chainId: '1', manager: '0x1a3b', label: 'C-AC' },
       ],
     })
+  })
+
+  it('carries pool.links.documents through migration', () => {
+    const legacy = legacyFixture()
+    legacy.pool.links = {
+      executiveSummary: null,
+      documents: [{ key: 'tos', label: 'Terms', href: 'https://x.io/tos' }],
+    }
+    const v2 = migratePoolMetadataToV2(legacy)
+    expect(v2.pool.links.documents).to.deep.equal([{ key: 'tos', label: 'Terms', href: 'https://x.io/tos' }])
   })
 
   it('drops a stray pool.report (singular) non-schema field', () => {
@@ -659,5 +669,85 @@ describe('parsePoolMetadataV2', () => {
     }
     overview.links[0]!.target = { kind: 'linkRef' } // missing linkRef string
     expect(() => parsePoolMetadataV2(bad)).to.throw(/linkRef must be a string/)
+  })
+
+  // --- pool.links.documents (reusable named documents) ---
+
+  it('accepts pool.links.documents (file and href docs)', () => {
+    expect(() => parsePoolMetadataV2(mockPoolMetadataV2)).to.not.throw()
+  })
+
+  it('rejects a link document setting both file and href', () => {
+    const bad = clone(mockPoolMetadataV2)
+    bad.pool.links!.documents = [
+      { key: 'x', label: 'X', file: { uri: 'ipfs://Q', mime: 'application/pdf' }, href: 'https://x.io' },
+    ]
+    expect(() => parsePoolMetadataV2(bad)).to.throw(/exactly one of `file` or `href`/)
+  })
+
+  it('rejects a link document setting neither file nor href', () => {
+    const bad = clone(mockPoolMetadataV2)
+    bad.pool.links!.documents = [{ key: 'x', label: 'X' } as never]
+    expect(() => parsePoolMetadataV2(bad)).to.throw(/exactly one of `file` or `href`/)
+  })
+
+  it('rejects duplicate link-document keys', () => {
+    const bad = clone(mockPoolMetadataV2)
+    bad.pool.links!.documents = [
+      { key: 'dup', label: 'A', href: 'https://a.io' },
+      { key: 'dup', label: 'B', href: 'https://b.io' },
+    ]
+    expect(() => parsePoolMetadataV2(bad)).to.throw(/is duplicated/)
+  })
+
+  it('rejects a link-document key colliding with a built-in', () => {
+    const bad = clone(mockPoolMetadataV2)
+    bad.pool.links!.documents = [{ key: 'website', label: 'W', href: 'https://w.io' }]
+    expect(() => parsePoolMetadataV2(bad)).to.throw(/collides with a built-in/)
+  })
+
+  it('rejects a link document with an empty key', () => {
+    const bad = clone(mockPoolMetadataV2)
+    bad.pool.links!.documents = [{ key: '', label: 'X', href: 'https://x.io' }]
+    expect(() => parsePoolMetadataV2(bad)).to.throw(/key must be a non-empty string/)
+  })
+})
+
+describe('resolveLinkTarget', () => {
+  const links = mockPoolMetadataV2.pool.links
+
+  it('resolves inline file and href targets', () => {
+    expect(
+      resolveLinkTarget(links, { kind: 'file', file: { uri: 'ipfs://Q', mime: 'application/pdf' } })
+    ).to.deep.equal({
+      file: { uri: 'ipfs://Q', mime: 'application/pdf' },
+    })
+    expect(resolveLinkTarget(links, { kind: 'href', href: 'https://x.io' })).to.deep.equal({ href: 'https://x.io' })
+  })
+
+  it('resolves built-in linkRefs (executiveSummary -> file, website/forum -> url)', () => {
+    expect(resolveLinkTarget(links, { kind: 'linkRef', linkRef: 'executiveSummary' })).to.deep.equal({
+      file: links.executiveSummary,
+    })
+    expect(resolveLinkTarget(links, { kind: 'linkRef', linkRef: 'website' })).to.deep.equal({
+      href: 'https://newsilver.com',
+    })
+    expect(resolveLinkTarget(links, { kind: 'linkRef', linkRef: 'forum' })).to.deep.equal({
+      href: 'https://gov.centrifuge.io/tag/newsilver',
+    })
+  })
+
+  it('resolves named documents by key (file or href)', () => {
+    expect(resolveLinkTarget(links, { kind: 'linkRef', linkRef: 'prospectus' })).to.deep.equal({
+      file: { uri: 'ipfs://QmProspectusDoc', mime: 'application/pdf' },
+    })
+    expect(resolveLinkTarget(links, { kind: 'linkRef', linkRef: 'termsOfService' })).to.deep.equal({
+      href: 'https://example.com/tos',
+    })
+  })
+
+  it('returns null for an unknown linkRef or missing links', () => {
+    expect(resolveLinkTarget(links, { kind: 'linkRef', linkRef: 'nope' })).to.equal(null)
+    expect(resolveLinkTarget(undefined, { kind: 'linkRef', linkRef: 'website' })).to.equal(null)
   })
 })

--- a/src/utils/poolMetadataMigration.test.ts
+++ b/src/utils/poolMetadataMigration.test.ts
@@ -230,13 +230,12 @@ describe('migratePoolMetadataToV2', () => {
     ])
   })
 
-  it('projects description, details and rating reports into body blocks', () => {
+  it('projects description and details into body blocks (no Documents block in body)', () => {
     const { body } = migratePoolMetadataToV2(legacyFixture()).pool.factsheet!
     expect(body).to.deep.equal([
       { type: 'text', id: 'overview', title: 'Overview', body: 'A long issuer description.' },
       { type: 'text', id: 'detail-0', title: 'Strategy', body: 'We do things.' },
       { type: 'text', id: 'detail-1', title: 'Risks', body: 'Things can go wrong.' },
-      { type: 'text', id: 'documents', title: 'Documents', body: '- [Moodys rating report](ipfs://Qm1)' },
       { type: 'section', id: 'performance', ref: 'onchainMetrics' },
     ])
   })
@@ -269,34 +268,45 @@ describe('migratePoolMetadataToV2', () => {
     })
   })
 
-  it('drops unsafe document URI schemes and escapes the rating label', () => {
+  it('builds a Documents tile section (full-width) from rating reports, dropping unsafe URIs', () => {
     const legacy = legacyFixture()
     legacy.pool.poolRatings = [
-      { agency: 'Evil [x](javascript:alert(1))', reportFile: { uri: 'javascript:alert(1)', mime: 'text/html' } },
+      { agency: 'Evil', reportFile: { uri: 'javascript:alert(1)', mime: 'text/html' } },
       { agency: 'Fitch', reportFile: { uri: 'https://x.io/r2', mime: 'application/pdf' } },
     ]
-    const documents = migratePoolMetadataToV2(legacy).pool.factsheet!.body.find((b) => b.id === 'documents')
+    const { body, sections } = migratePoolMetadataToV2(legacy).pool.factsheet!
+    expect(body.some((b) => b.id === 'documents')).to.equal(false) // not in the header region
+    const documents = sections!.find((s) => s.id === 'documents')
     expect(documents).to.deep.equal({
-      type: 'text',
+      type: 'documents',
       id: 'documents',
       title: 'Documents',
-      body: '- [Fitch rating report](https://x.io/r2)',
+      items: [
+        {
+          title: 'Fitch rating report',
+          target: { kind: 'file', file: { uri: 'https://x.io/r2', mime: 'application/pdf' } },
+        },
+      ],
     })
   })
 
-  it('omits the Documents block entirely when no rating has a safe URI', () => {
+  it('omits the Documents block entirely when no rating has a safe report URI', () => {
     const legacy = legacyFixture()
     legacy.pool.poolRatings = [{ agency: 'X', reportFile: { uri: 'javascript:alert(1)', mime: 'text/html' } }]
-    const documents = migratePoolMetadataToV2(legacy).pool.factsheet!.body.find((b) => b.id === 'documents')
-    expect(documents).to.equal(undefined)
+    const { body, sections } = migratePoolMetadataToV2(legacy).pool.factsheet!
+    expect(body.some((b) => b.id === 'documents')).to.equal(false)
+    expect((sections ?? []).some((s) => s.id === 'documents')).to.equal(false)
   })
 
-  it('omits sections (app renders defaults) when there is no holdings blob', () => {
-    expect(migratePoolMetadataToV2(legacyFixture()).pool.factsheet!.sections).to.equal(undefined)
+  it('omits sections (app renders defaults) when there is no documents block or holdings blob', () => {
+    const legacy = legacyFixture()
+    legacy.pool.poolRatings = [] // no rating reports => no Documents section
+    expect(migratePoolMetadataToV2(legacy).pool.factsheet!.sections).to.equal(undefined)
   })
 
   it('folds the legacy holdings blob into a table section, faithfully, dropping no column', () => {
     const legacy = legacyFixture()
+    legacy.pool.poolRatings = [] // isolate the holdings section
     legacy.holdings = {
       headers: ['Asset', 'ISIN', 'Amount'],
       data: [
@@ -323,10 +333,12 @@ describe('migratePoolMetadataToV2', () => {
 
   it('skips the holdings table when headers are empty or data is missing', () => {
     const emptyHeaders = legacyFixture()
+    emptyHeaders.pool.poolRatings = []
     emptyHeaders.holdings = { headers: [], data: [{ x: 1 }] }
     expect(migratePoolMetadataToV2(emptyHeaders).pool.factsheet!.sections).to.equal(undefined)
 
     const missingData = legacyFixture()
+    missingData.pool.poolRatings = []
     missingData.holdings = { headers: ['A'] } as unknown as PoolMetadataV1['holdings']
     expect(migratePoolMetadataToV2(missingData).pool.factsheet!.sections).to.equal(undefined)
   })

--- a/src/utils/poolMetadataMigration.ts
+++ b/src/utils/poolMetadataMigration.ts
@@ -187,7 +187,19 @@ function buildFactsheet(
 
   const body: LayoutItem[] = []
   if (issuer.description) {
-    body.push({ type: 'text', id: 'overview', title: 'Overview', body: issuer.description })
+    // Overview card: logo and the "Factsheet" link button are added only when their source field
+    // exists, so a missing logo / executiveSummary degrades to a plain card (never a broken one).
+    // The Factsheet link references the typed `links.executiveSummary` rather than copying its URI.
+    body.push({
+      type: 'text',
+      id: 'overview',
+      title: 'Overview',
+      body: issuer.description,
+      ...(issuer.logo?.uri ? { logo: issuer.logo } : {}),
+      ...(pool.links?.executiveSummary?.uri
+        ? { links: [{ label: 'Factsheet', target: { kind: 'linkRef', linkRef: 'executiveSummary' } }] }
+        : {}),
+    })
   }
   asArray(details).forEach((detail, index) => {
     body.push({ type: 'text', id: `detail-${index}`, title: detail.title, body: detail.body })
@@ -387,7 +399,8 @@ function upgradeLegacyV2(doc: PoolMetadataV2): PoolMetadataV2 {
 // (see centrifuge/apps-invest#200), but the SDK is the alignment point: an unknown key is rejected
 // on WRITE so the management app, SDK, and invest app stay in sync (adding a key ships in an SDK
 // release). The read path does not validate, so a newer document never breaks an older reader.
-const VISIBILITIES = new Set<Visibility>(['public', 'whitelisted', 'hidden'])
+const VISIBILITIES = new Set<Visibility>(['public', 'whitelisted', 'geo-blocked', 'hidden'])
+const REGION_CODE_RE = /^[A-Za-z]{2}$/
 const CHART_TYPES = new Set<ChartType>(['line', 'area', 'bar', 'donut'])
 const AXIS_FORMATS = new Set<AxisFormat>(['number', 'percent', 'currency'])
 const XAXIS_TYPES = new Set(['category', 'time', 'number'])
@@ -397,7 +410,17 @@ const LIVE_METRICS = new Set<LiveMetric>(['tokenPrice', 'nav', 'apy30d', 'navCha
 const LIVE_DATASETS = new Set<LiveDataset>(['monthlySummary'])
 const KEY_FACT_REFS = new Set(['apy', 'availableNetworks', 'ratings'])
 const COLUMN_FORMATS = new Set<ColumnFormat>(['text', 'number', 'percent', 'currency'])
-const CONTENT_BLOCK_TYPES = new Set(['text', 'table', 'chart', 'image', 'kpiGroup', 'tabGroup', 'liveTable'])
+const CONTENT_BLOCK_TYPES = new Set([
+  'text',
+  'table',
+  'chart',
+  'image',
+  'kpiGroup',
+  'tabGroup',
+  'liveTable',
+  'documents',
+  'accordion',
+])
 const TAB_BLOCK_TYPES = new Set(['text', 'table', 'chart', 'kpiGroup'])
 const KPI_TRENDS = new Set(['up', 'down', 'neutral'])
 
@@ -428,6 +451,24 @@ function validateFile(value: unknown, where: string): void {
   if (!isObject(value)) fail(`${where} must be a file object`)
   assertString(value.uri, `${where}.uri`)
   assertString(value.mime, `${where}.mime`)
+}
+
+function validateLinkTarget(value: unknown, where: string): void {
+  if (!isObject(value)) fail(`${where} must be an object`)
+  switch (value.kind) {
+    case 'file':
+      validateFile(value.file, `${where}.file`)
+      break
+    case 'href':
+      assertString(value.href, `${where}.href`)
+      break
+    case 'linkRef':
+      // Resolved app-side against the typed `pool.links`; an unknown key hides the link (lenient).
+      assertString(value.linkRef, `${where}.linkRef`)
+      break
+    default:
+      fail(`${where} has an invalid kind "${String(value.kind)}"`)
+  }
 }
 
 function validateIconRef(value: unknown, where: string): void {
@@ -533,6 +574,17 @@ function validateContentBlock(block: Record<string, unknown>, type: string, wher
   switch (type) {
     case 'text':
       assertString(block.body, `${where}.body`)
+      // Optional Overview-card extras.
+      if (block.logo !== undefined) validateFile(block.logo, `${where}.logo`)
+      if (block.background !== undefined) assertString(block.background, `${where}.background`)
+      if (block.links !== undefined) {
+        if (!Array.isArray(block.links)) fail(`${where}.links must be an array`)
+        block.links.forEach((link, index) => {
+          if (!isObject(link)) fail(`${where}.links[${index}] must be an object`)
+          assertString(link.label, `${where}.links[${index}].label`)
+          validateLinkTarget(link.target, `${where}.links[${index}].target`)
+        })
+      }
       break
     case 'table': {
       if (!Array.isArray(block.headers) || !block.headers.every((h) => typeof h === 'string')) {
@@ -606,13 +658,7 @@ function validateContentBlock(block: Record<string, unknown>, type: string, wher
       block.tabs.forEach((tab, index) => {
         if (!isObject(tab)) fail(`${where}.tabs[${index}] must be an object`)
         assertString(tab.label, `${where}.tabs[${index}].label`)
-        if (!isObject(tab.block)) fail(`${where}.tabs[${index}].block must be an object`)
-        const tabBlock = tab.block
-        if (typeof tabBlock.type !== 'string' || !TAB_BLOCK_TYPES.has(tabBlock.type)) {
-          fail(`${where}.tabs[${index}].block has an invalid type "${String(tabBlock.type)}"`)
-        }
-        assertString(tabBlock.id, `${where}.tabs[${index}].block.id`)
-        validateContentBlock(tabBlock, tabBlock.type, `${where}.tabs[${index}].block`)
+        validateTabBlock(tab.block, `${where}.tabs[${index}].block`)
       })
       break
     }
@@ -624,9 +670,40 @@ function validateContentBlock(block: Record<string, unknown>, type: string, wher
       block.columns.forEach((column, index) => validateLiveColumn(column, `${where}.columns[${index}]`))
       break
     }
+    case 'documents': {
+      if (!Array.isArray(block.items)) fail(`${where}.items must be an array`)
+      block.items.forEach((item, index) => {
+        if (!isObject(item)) fail(`${where}.items[${index}] must be an object`)
+        assertString(item.title, `${where}.items[${index}].title`)
+        validateLinkTarget(item.target, `${where}.items[${index}].target`)
+      })
+      break
+    }
+    case 'accordion': {
+      if (!Array.isArray(block.items)) fail(`${where}.items must be an array`)
+      block.items.forEach((item, index) => {
+        if (!isObject(item)) fail(`${where}.items[${index}] must be an object`)
+        assertString(item.title, `${where}.items[${index}].title`)
+        if (item.defaultOpen !== undefined && typeof item.defaultOpen !== 'boolean') {
+          fail(`${where}.items[${index}].defaultOpen must be a boolean`)
+        }
+        validateTabBlock(item.block, `${where}.items[${index}].block`)
+      })
+      break
+    }
     default:
       fail(`${where} has an unknown block type "${type}"`)
   }
+}
+
+/** Validates a leaf block nested in a `tabGroup` tab or `accordion` item (the {@link TabBlock} set). */
+function validateTabBlock(value: unknown, where: string): void {
+  if (!isObject(value)) fail(`${where} must be an object`)
+  if (typeof value.type !== 'string' || !TAB_BLOCK_TYPES.has(value.type)) {
+    fail(`${where} has an invalid type "${String(value.type)}"`)
+  }
+  assertString(value.id, `${where}.id`)
+  validateContentBlock(value, value.type, where)
 }
 
 function validateLayoutItem(item: unknown, where: string): void {
@@ -674,6 +751,18 @@ export function parsePoolMetadataV2(raw: unknown): PoolMetadataV2 {
   if (raw.version !== 2) fail(`expected version 2, got ${String(raw.version)}`)
   if (!isObject(raw.pool)) fail('`pool` must be an object')
   assertString(raw.pool.name, '`pool.name`')
+  if (raw.pool.geoBlock !== undefined) validateGeoBlock(raw.pool.geoBlock)
   if (raw.pool.factsheet !== undefined) validateFactsheet(raw.pool.factsheet)
   return raw as PoolMetadataV2
+}
+
+/** Validates `pool.geoBlock.regions` as ISO 3166-1 alpha-2 codes (format only, strict on write). */
+function validateGeoBlock(geoBlock: unknown): void {
+  if (!isObject(geoBlock)) fail('`pool.geoBlock` must be an object')
+  if (!Array.isArray(geoBlock.regions)) fail('`pool.geoBlock.regions` must be an array')
+  geoBlock.regions.forEach((region, index) => {
+    if (typeof region !== 'string' || !REGION_CODE_RE.test(region)) {
+      fail(`pool.geoBlock.regions[${index}] must be an ISO 3166-1 alpha-2 code, got "${String(region)}"`)
+    }
+  })
 }

--- a/src/utils/poolMetadataMigration.ts
+++ b/src/utils/poolMetadataMigration.ts
@@ -20,7 +20,7 @@ import {
   type PoolMetadataV2,
   type SectionRef,
   type TableBlock,
-  type Visibility,
+  type VisibilityGate,
 } from '../types/poolMetadata.js'
 
 /* ================================================================================================
@@ -399,7 +399,8 @@ function upgradeLegacyV2(doc: PoolMetadataV2): PoolMetadataV2 {
 // (see centrifuge/apps-invest#200), but the SDK is the alignment point: an unknown key is rejected
 // on WRITE so the management app, SDK, and invest app stay in sync (adding a key ships in an SDK
 // release). The read path does not validate, so a newer document never breaks an older reader.
-const VISIBILITIES = new Set<Visibility>(['public', 'whitelisted', 'geo-blocked', 'hidden'])
+const VISIBILITY_SCALARS = new Set(['public', 'hidden', 'whitelisted', 'geo-restricted'])
+const VISIBILITY_GATES = new Set<VisibilityGate>(['whitelisted', 'geo-restricted'])
 const REGION_CODE_RE = /^[A-Za-z]{2}$/
 const CHART_TYPES = new Set<ChartType>(['line', 'area', 'bar', 'donut'])
 const AXIS_FORMATS = new Set<AxisFormat>(['number', 'percent', 'currency'])
@@ -438,9 +439,24 @@ function assertString(value: unknown, where: string): asserts value is string {
 
 function assertVisibility(value: unknown, where: string): void {
   if (value === undefined) return
-  if (typeof value !== 'string' || !VISIBILITIES.has(value as Visibility)) {
-    fail(`${where} has invalid visibility "${String(value)}"`)
+  if (typeof value === 'string') {
+    if (!VISIBILITY_SCALARS.has(value)) fail(`${where} has invalid visibility "${value}"`)
+    return
   }
+  // An array combines gates with AND. `public`/`hidden` are scalars, never array members.
+  if (Array.isArray(value)) {
+    if (value.length === 0) fail(`${where} visibility array must not be empty`)
+    const seen = new Set<string>()
+    value.forEach((gate) => {
+      if (typeof gate !== 'string' || !VISIBILITY_GATES.has(gate as VisibilityGate)) {
+        fail(`${where} has an invalid visibility gate "${String(gate)}"`)
+      }
+      if (seen.has(gate)) fail(`${where} has a duplicate visibility gate "${gate}"`)
+      seen.add(gate)
+    })
+    return
+  }
+  fail(`${where} has invalid visibility "${String(value)}"`)
 }
 
 function isPrimitiveCell(value: unknown): value is string | number {
@@ -751,18 +767,18 @@ export function parsePoolMetadataV2(raw: unknown): PoolMetadataV2 {
   if (raw.version !== 2) fail(`expected version 2, got ${String(raw.version)}`)
   if (!isObject(raw.pool)) fail('`pool` must be an object')
   assertString(raw.pool.name, '`pool.name`')
-  if (raw.pool.geoBlock !== undefined) validateGeoBlock(raw.pool.geoBlock)
+  if (raw.pool.geoRestrictions !== undefined) validateGeoRestrictions(raw.pool.geoRestrictions)
   if (raw.pool.factsheet !== undefined) validateFactsheet(raw.pool.factsheet)
   return raw as PoolMetadataV2
 }
 
-/** Validates `pool.geoBlock.regions` as ISO 3166-1 alpha-2 codes (format only, strict on write). */
-function validateGeoBlock(geoBlock: unknown): void {
-  if (!isObject(geoBlock)) fail('`pool.geoBlock` must be an object')
-  if (!Array.isArray(geoBlock.regions)) fail('`pool.geoBlock.regions` must be an array')
-  geoBlock.regions.forEach((region, index) => {
+/** Validates `pool.geoRestrictions.regions` as ISO 3166-1 alpha-2 codes (format only, strict on write). */
+function validateGeoRestrictions(geoRestrictions: unknown): void {
+  if (!isObject(geoRestrictions)) fail('`pool.geoRestrictions` must be an object')
+  if (!Array.isArray(geoRestrictions.regions)) fail('`pool.geoRestrictions.regions` must be an array')
+  geoRestrictions.regions.forEach((region, index) => {
     if (typeof region !== 'string' || !REGION_CODE_RE.test(region)) {
-      fail(`pool.geoBlock.regions[${index}] must be an ISO 3166-1 alpha-2 code, got "${String(region)}"`)
+      fail(`pool.geoRestrictions.regions[${index}] must be an ISO 3166-1 alpha-2 code, got "${String(region)}"`)
     }
   })
 }

--- a/src/utils/poolMetadataMigration.ts
+++ b/src/utils/poolMetadataMigration.ts
@@ -5,6 +5,7 @@ import {
   type ChartType,
   type ColumnFormat,
   type DataRef,
+  type DocumentsBlock,
   type Factsheet,
   isPoolMetadataV2,
   type KeyFact,
@@ -109,9 +110,18 @@ function isSafeDocumentUri(uri: string): boolean {
   return scheme.startsWith('https://') || scheme.startsWith('ipfs://')
 }
 
-/** Escapes markdown link-breaking characters so an issuer-supplied label can't alter the link. */
-function escapeMarkdownText(text: string): string {
-  return text.replace(/[\\[\]()]/g, '\\$&').replace(/\s+/g, ' ')
+/**
+ * Builds a `documents` section from the rating report files (a tile per safe-URI report), or null
+ * when none have a usable report. Each tile targets the report file directly (`kind: 'file'`).
+ */
+function ratingDocumentsBlock(poolRatings: PoolMetadataV1['pool']['poolRatings']): DocumentsBlock | null {
+  const items = asArray(poolRatings)
+    .filter((rating) => rating.reportFile?.uri && isSafeDocumentUri(rating.reportFile.uri))
+    .map((rating) => ({
+      title: `${rating.agency ?? 'Rating'} rating report`,
+      target: { kind: 'file' as const, file: rating.reportFile! },
+    }))
+  return items.length > 0 ? { type: 'documents', id: 'documents', title: 'Documents', items } : null
 }
 
 /**
@@ -204,28 +214,18 @@ function buildFactsheet(
   asArray(details).forEach((detail, index) => {
     body.push({ type: 'text', id: `detail-${index}`, title: detail.title, body: detail.body })
   })
-  // Ratings reports are surfaced two ways: a Documents body block (markdown links to the report
-  // PDFs) and the `ratings` key-fact ref pill above. Both read the same typed `poolRatings` field.
-  const ratingsWithReports = asArray(poolRatings).filter(
-    (rating) => rating.reportFile?.uri && isSafeDocumentUri(rating.reportFile.uri)
-  )
-  if (ratingsWithReports.length > 0) {
-    body.push({
-      type: 'text',
-      id: 'documents',
-      title: 'Documents',
-      body: ratingsWithReports
-        .map(
-          (rating) => `- [${escapeMarkdownText(rating.agency ?? 'Rating')} rating report](${rating.reportFile!.uri})`
-        )
-        .join('\n'),
-    })
-  }
   body.push({ type: 'section', id: 'performance', ref: 'onchainMetrics' })
 
+  // Full-width region. Rating reports become a `documents` tile block (ratings are also surfaced
+  // as the `ratings` key-fact ref pill above; both read the same typed `poolRatings`). `sections` is
+  // omitted (so the invest app renders its defaults) only when there is neither a documents block
+  // nor a holdings table.
+  const sections: LayoutItem[] = []
+  const documentsBlock = ratingDocumentsBlock(poolRatings)
+  if (documentsBlock) sections.push(documentsBlock)
   const holdingsBlock = holdingsTableBlock(holdings)
-  // `sections` is omitted (so the invest app renders its defaults) unless we have a holdings table.
-  return holdingsBlock ? { body, keyFacts, sections: [holdingsBlock] } : { body, keyFacts }
+  if (holdingsBlock) sections.push(holdingsBlock)
+  return sections.length > 0 ? { body, keyFacts, sections } : { body, keyFacts }
 }
 
 /**

--- a/src/utils/poolMetadataMigration.ts
+++ b/src/utils/poolMetadataMigration.ts
@@ -7,12 +7,14 @@ import {
   type DataRef,
   type DocumentsBlock,
   type Factsheet,
+  type FileType,
   isPoolMetadataV2,
   type KeyFact,
   type KeyFactGroup,
   type KeyFactValue,
   type LayoutItem,
   type LegacyApyMode,
+  type LinkTarget,
   type LiveDataset,
   type LiveMetric,
   type PoolMetadata,
@@ -469,6 +471,28 @@ function validateFile(value: unknown, where: string): void {
   assertString(value.mime, `${where}.mime`)
 }
 
+const BUILTIN_LINK_KEYS = new Set(['executiveSummary', 'website', 'forum'])
+
+function validateLinkDocuments(documents: unknown): void {
+  if (!Array.isArray(documents)) fail('`pool.links.documents` must be an array')
+  const seen = new Set<string>()
+  documents.forEach((doc, index) => {
+    const where = `pool.links.documents[${index}]`
+    if (!isObject(doc)) fail(`${where} must be an object`)
+    if (typeof doc.key !== 'string' || doc.key.length === 0) fail(`${where}.key must be a non-empty string`)
+    if (typeof doc.label !== 'string' || doc.label.length === 0) fail(`${where}.label must be a non-empty string`)
+    // Exactly one of file (object) or non-empty href. A null file counts as absent.
+    const hasFile = isObject(doc.file)
+    const hasHref = typeof doc.href === 'string' && doc.href.length > 0
+    if (hasFile === hasHref) fail(`${where} must set exactly one of \`file\` or \`href\``)
+    if (hasFile) validateFile(doc.file, `${where}.file`)
+    // Built-ins resolve first, so a colliding key would be ambiguous (unreachable).
+    if (BUILTIN_LINK_KEYS.has(doc.key)) fail(`${where}.key "${doc.key}" collides with a built-in link key`)
+    if (seen.has(doc.key)) fail(`${where}.key "${doc.key}" is duplicated`)
+    seen.add(doc.key)
+  })
+}
+
 function validateLinkTarget(value: unknown, where: string): void {
   if (!isObject(value)) fail(`${where} must be an object`)
   switch (value.kind) {
@@ -768,8 +792,42 @@ export function parsePoolMetadataV2(raw: unknown): PoolMetadataV2 {
   if (!isObject(raw.pool)) fail('`pool` must be an object')
   assertString(raw.pool.name, '`pool.name`')
   if (raw.pool.geoRestrictions !== undefined) validateGeoRestrictions(raw.pool.geoRestrictions)
+  if (isObject(raw.pool.links) && raw.pool.links.documents !== undefined) {
+    validateLinkDocuments(raw.pool.links.documents)
+  }
   if (raw.pool.factsheet !== undefined) validateFactsheet(raw.pool.factsheet)
   return raw as PoolMetadataV2
+}
+
+/**
+ * Resolves a {@link LinkTarget} to a `{ href }` or `{ file }` against a pool's `links`. `linkRef`
+ * checks the built-in keys first (`executiveSummary` -> file, `website`/`forum` -> url), then
+ * `links.documents` by `key`. Returns `null` on no match (callers self-blank; never throw). Shared
+ * so the SDK and the invest app resolve references identically.
+ */
+export function resolveLinkTarget(
+  links: PoolMetadataV1['pool']['links'] | undefined,
+  target: LinkTarget
+): { href?: string; file?: FileType } | null {
+  switch (target.kind) {
+    case 'file':
+      return { file: target.file }
+    case 'href':
+      return { href: target.href }
+    case 'linkRef': {
+      const key = target.linkRef
+      if (key === 'executiveSummary') return links?.executiveSummary ? { file: links.executiveSummary } : null
+      if (key === 'website') return links?.website ? { href: links.website } : null
+      if (key === 'forum') return links?.forum ? { href: links.forum } : null
+      const doc = links?.documents?.find((d) => d.key === key)
+      if (!doc) return null
+      if (doc.file) return { file: doc.file }
+      if (doc.href) return { href: doc.href }
+      return null
+    }
+    default:
+      return null
+  }
 }
 
 /** Validates `pool.geoRestrictions.regions` as ISO 3166-1 alpha-2 codes (format only, strict on write). */


### PR DESCRIPTION
## Summary

Implements centrifuge/sdk#482 — additive `version: 2` schema work. All changes are additive (a v2 document without these fields still parses), and validation follows the established v2 pattern (closed `Visibility` union, strict-on-write where it's a closed set, lenient/graceful where the app resolves a reference).

## Geo-blocking

- `Visibility` gains **`geo-blocked`** (now `'public' | 'whitelisted' | 'geo-blocked' | 'hidden'`).
- New **`pool.geoBlock?: { regions: string[] }`** — a single pool-level blocked-regions list (ISO 3166-1 alpha-2). Every `geo-blocked` element gates against it; presentational only, resolved app-side.
- Validation: `geoBlock.regions` format-validated as alpha-2 (rejected on write otherwise).
- **Open decision (resolved per the issue's recommendation):** a `geo-blocked` element with **no** `geoBlock` list is *not* an error — nothing is blocked (effectively `public`). No cross-field requirement.

## New factsheet primitives

- **`LinkTarget`** union (shared): `{ kind:'file'; file } | { kind:'href'; href } | { kind:'linkRef'; linkRef }`. `linkRef` points at a key in the typed `pool.links` (single source of truth); the app resolves it and hides the link on an unknown key (shape-only validation, lenient read).
- **`documents`** block — a tile list (`items: { title; target: LinkTarget }[]`), e.g. a "Fact Sheet" tile.
- **`accordion`** block — a collapsible stack (`items: { title; block: TabBlock; defaultOpen? }[]`), sibling to `tabGroup`, reusing the `TabBlock` leaf set.
- **`text` block extended** with optional `logo?: FileType`, `background?: string`, `links?: { label; target: LinkTarget }[]` (the Overview card).

## Migration (v1 → v2)

The Overview `text` block now carries the brand `logo` (← `issuer.logo`) and a **"Factsheet"** link whose target is `{ kind:'linkRef', linkRef:'executiveSummary' }` (referencing the typed `links.executiveSummary`, not copying its URI). Both are added **only when the source field exists** — a missing/empty logo or `executiveSummary` degrades to a plain card, never a broken one. Verified on the real Anemoy (logo + Factsheet link present) and deJAAA (both gracefully omitted) payloads.

## Reconcile (for the invest app)

`pool.geoBlock.regions` is intended to become the single source of truth for the region gate the invest app already has (`useIsRestrictedCountry` / `useGeolocation`). That wiring is app-side and out of scope here; flagging so the app reads `pool.geoBlock.regions`.

## Test status

`pnpm build` green; `pnpm test:unit` green (250) incl. new geo-block / documents / accordion / LinkTarget / overview-card cases; `eslint` clean. New types auto-export via `export * from './types/poolMetadata.js'`. Full Tenderly suite gated on `TENDERLY_ACCESS_KEY`, not run here. Version bump left to CI.

Ref: centrifuge/apps-invest#222, closes centrifuge/sdk#482
