### PR TITLE
feat(poolMetadata): add optional subtitle to factsheet blocks, sections and key-fact groups

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@centrifuge/sdk",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "description": "",
   "homepage": "https://github.com/centrifuge/sdk/tree/main#readme",
   "author": "",

--- a/src/tests/mocks/mockPoolMetadataV2.ts
+++ b/src/tests/mocks/mockPoolMetadataV2.ts
@@ -63,6 +63,7 @@ export const mockPoolMetadataV2: PoolMetadataV2 = {
           type: 'keyFactGroup',
           id: 'overview-facts',
           title: 'Overview',
+          subtitle: 'Fund-level summary',
           items: [
             { label: 'Issuer', value: { kind: 'text', text: 'Fake Issuer' } },
             { label: 'Asset type', value: { kind: 'text', text: 'Private credit - Fake Subclass' } },
@@ -100,6 +101,7 @@ export const mockPoolMetadataV2: PoolMetadataV2 = {
           type: 'text',
           id: 'overview',
           title: 'Overview',
+          subtitle: 'Underlying fund (CGUHY I)',
           body: 'Fake **overview** with a [link](https://x.io).',
           logo: { uri: 'ipfs://QmBrandLogo', mime: 'image/svg+xml' },
           background: '#0b1f3a',
@@ -168,7 +170,10 @@ export const mockPoolMetadataV2: PoolMetadataV2 = {
           type: 'tabGroup',
           id: 'tabs',
           tabs: [
-            { label: 'Summary', block: { type: 'text', id: 'tab-summary', body: 'Tab body text.' } },
+            {
+              label: 'Summary',
+              block: { type: 'text', id: 'tab-summary', title: 'Summary', subtitle: 'Tab sub-heading', body: 'Tab body text.' },
+            },
             {
               label: 'Numbers',
               block: { type: 'kpiGroup', id: 'tab-kpis', items: [{ label: 'NAV', value: '$1.02' }] },

--- a/src/types/poolMetadata.ts
+++ b/src/types/poolMetadata.ts
@@ -388,11 +388,18 @@ export type KeyFactGroup = {
   type: 'keyFactGroup'
   id: string
   title?: string
+  /** Optional secondary header rendered under {@link KeyFactGroup.title} (muted sub-heading). */
+  subtitle?: string
   visibility?: Visibility
   items: KeyFact[]
 }
 
-type BlockBase = { id: string; title?: string; visibility?: Visibility }
+/**
+ * Common fields on every content block. `title` is the primary header; `subtitle` is an optional
+ * secondary header rendered directly under it (muted sub-heading), e.g. title "Exposure breakdowns"
+ * with subtitle "Underlying fund (CGUHY I)".
+ */
+type BlockBase = { id: string; title?: string; subtitle?: string; visibility?: Visibility }
 
 /**
  * A single link destination, discriminated by `kind` (no competing-optional ambiguity):
@@ -531,6 +538,8 @@ export type SectionRefBlock = {
   ref: SectionRef
   /** Optional label override; the app supplies a sensible default. */
   title?: string
+  /** Optional secondary header rendered under {@link SectionRefBlock.title} (muted sub-heading). */
+  subtitle?: string
   visibility?: Visibility
 }
 

--- a/src/utils/poolMetadataMigration.test.ts
+++ b/src/utils/poolMetadataMigration.test.ts
@@ -505,6 +505,40 @@ describe('parsePoolMetadataV2', () => {
     expect(() => parsePoolMetadataV2(bad)).to.throw(/visibility/)
   })
 
+  it('accepts string subtitles on a block, a key-fact group and a tab block', () => {
+    const ok = clone(mockPoolMetadataV2)
+    ;(ok.pool.factsheet!.body[0] as Record<string, unknown>).subtitle = 'A block subtitle'
+    ok.pool.factsheet!.keyFacts[0]!.subtitle = 'A group subtitle'
+    const tabGroup = ok.pool.factsheet!.body.find((b) => b.id === 'tabs') as { tabs: { block: Record<string, unknown> }[] }
+    tabGroup.tabs[0]!.block.subtitle = 'A tab subtitle'
+    expect(() => parsePoolMetadataV2(ok)).to.not.throw()
+  })
+
+  it('rejects a non-string subtitle on a block', () => {
+    const bad = clone(mockPoolMetadataV2)
+    ;(bad.pool.factsheet!.body[0] as Record<string, unknown>).subtitle = 123
+    expect(() => parsePoolMetadataV2(bad)).to.throw(/subtitle/)
+  })
+
+  it('rejects a non-string subtitle on a key-fact group', () => {
+    const bad = clone(mockPoolMetadataV2)
+    ;(bad.pool.factsheet!.keyFacts[0] as Record<string, unknown>).subtitle = 123
+    expect(() => parsePoolMetadataV2(bad)).to.throw(/subtitle/)
+  })
+
+  it('rejects a non-string subtitle inside a tab block', () => {
+    const bad = clone(mockPoolMetadataV2)
+    const tabGroup = bad.pool.factsheet!.body.find((b) => b.id === 'tabs') as { tabs: { block: Record<string, unknown> }[] }
+    tabGroup.tabs[0]!.block.subtitle = 123
+    expect(() => parsePoolMetadataV2(bad)).to.throw(/subtitle/)
+  })
+
+  it('rejects a non-string title on a block', () => {
+    const bad = clone(mockPoolMetadataV2)
+    ;(bad.pool.factsheet!.body[0] as Record<string, unknown>).title = 123
+    expect(() => parsePoolMetadataV2(bad)).to.throw(/title/)
+  })
+
   it('rejects a block missing its id', () => {
     const bad = clone(mockPoolMetadataV2)
     delete (bad.pool.factsheet!.body[0] as Record<string, unknown>).id

--- a/src/utils/poolMetadataMigration.ts
+++ b/src/utils/poolMetadataMigration.ts
@@ -563,6 +563,7 @@ function validateKeyFactGroup(value: unknown, where: string): void {
   if (value.type !== 'keyFactGroup') fail(`${where}.type must be 'keyFactGroup'`)
   assertString(value.id, `${where}.id`)
   if (value.title !== undefined) assertString(value.title, `${where}.title`)
+  if (value.subtitle !== undefined) assertString(value.subtitle, `${where}.subtitle`)
   assertVisibility(value.visibility, where)
   if (!Array.isArray(value.items)) fail(`${where}.items must be an array`)
   value.items.forEach((item, index) => validateKeyFact(item, `${where}.items[${index}]`))
@@ -743,6 +744,8 @@ function validateTabBlock(value: unknown, where: string): void {
     fail(`${where} has an invalid type "${String(value.type)}"`)
   }
   assertString(value.id, `${where}.id`)
+  if (value.title !== undefined) assertString(value.title, `${where}.title`)
+  if (value.subtitle !== undefined) assertString(value.subtitle, `${where}.subtitle`)
   validateContentBlock(value, value.type, where)
 }
 
@@ -750,6 +753,8 @@ function validateLayoutItem(item: unknown, where: string): void {
   if (!isObject(item)) fail(`${where} must be an object`)
   if (typeof item.type !== 'string') fail(`${where} is missing a string \`type\``)
   assertString(item.id, `${where}.id`)
+  if (item.title !== undefined) assertString(item.title, `${where}.title`)
+  if (item.subtitle !== undefined) assertString(item.subtitle, `${where}.subtitle`)
   assertVisibility(item.visibility, where)
 
   if (item.type === 'section') {


### PR DESCRIPTION
## Summary

Adds an optional `subtitle` to the pool-metadata v2 factsheet model: a secondary header rendered directly under `title` (muted sub-heading). Example: title **"Exposure breakdowns"** with subtitle "Underlying fund (CGUHY I)".

Mostly additive (no schema-shape change; older readers and all existing documents are unaffected), with **one small, intentional validation tightening** on the write path — see "Behavior change" below.

## What's in here

- **Types** (`src/types/poolMetadata.ts`): `subtitle?: string` on `BlockBase` (so every content block — `text`/`table`/`chart`/`image`/`kpiGroup`/`tabGroup`/`liveTable`/`documents`/`accordion`), on `SectionRefBlock`, and on `KeyFactGroup`.
- **Validation** (`src/utils/poolMetadataMigration.ts`): `parsePoolMetadataV2` asserts `subtitle` as an optional string at the layout-item, tab-block and key-fact-group levels, and likewise tightens `title` validation (see below).
- **Tests** (`poolMetadataMigration.test.ts`, `mockPoolMetadataV2.ts`): `subtitle` added to the mock (a `keyFactGroup`, a body `text` block, a tab block) so the accept path is exercised; plus explicit accept tests and non-string-`subtitle` rejection at block / key-fact-group / tab-block level, and a non-string-`title` rejection test.

## ⚠️ Behavior change — `title` validation tightened (intentional, not just additive)

Titles are **not** newly required — `title` stays optional everywhere (`title?: string`). What changed: `parsePoolMetadataV2` now validates that a `title`, **when present**, is a string on **layout items (body/section blocks)** and **tab blocks**. Previously those node types validated only `id` and `visibility`, so a non-string `title` (e.g. a number) passed silently; now it throws. This aligns them with the existing `keyFactGroup` behavior and with the `title?: string` type.

- Scope: **write path only** (`parsePoolMetadataV2`). Reads are unvalidated and unaffected; no existing document is impacted unless it carries a non-string `title` (already invalid against the types).
- Covered by the `rejects a non-string title on a block` test.
- Changelog note: minor validation fix, not breaking for any well-typed document.

## Compatibility

- Reads unaffected. Writes unaffected for any document with valid (string-or-absent) `title`/`subtitle`.
- No migration needed.

## Test status

Tests added (above). `pnpm build` / `pnpm test:unit` were **not run in this environment** (no `node_modules`/deps here); they follow the existing `clone(mockPoolMetadataV2)` + `expect(...).to.throw(/…/)` patterns and run in CI.

Ref: centrifuge/apps-invest#200
