### PR TITLE
feat(poolMetadata): two-column columns block + kpiGroup delta/secondary/variant

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@centrifuge/sdk",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "description": "",
   "homepage": "https://github.com/centrifuge/sdk/tree/main#readme",
   "author": "",

--- a/src/tests/mocks/mockPoolMetadataV2.ts
+++ b/src/tests/mocks/mockPoolMetadataV2.ts
@@ -160,9 +160,11 @@ export const mockPoolMetadataV2: PoolMetadataV2 = {
           type: 'kpiGroup',
           id: 'kpis',
           columns: 3,
+          variant: 'cards',
           items: [
             { label: 'TVL', value: '$10M' },
             { label: 'Investors', value: '120', trend: 'up' },
+            { label: 'Yield to worst', value: '6.49%', delta: '-0.47%', trend: 'up', secondary: 'vs 6.96%' },
             { label: 'Hidden KPI', value: 'secret', visibility: 'hidden' },
           ],
         },
@@ -240,6 +242,36 @@ export const mockPoolMetadataV2: PoolMetadataV2 = {
           rows: [
             ['T-Bill 2026', 'US912796RW0', 1_000_000],
             ['T-Bill 2027', '', 2_500_000],
+          ],
+        },
+        {
+          type: 'columns',
+          id: 'risk',
+          ratio: '3:2',
+          left: [
+            {
+              type: 'kpiGroup',
+              id: 'risk-drawdown',
+              title: 'Risk & drawdown',
+              subtitle: 'Underlying fund',
+              columns: 4,
+              items: [
+                { label: 'Max drawdown', value: '-19.3%' },
+                { label: 'Recovery to prior peak', value: '162 days', trend: 'up' },
+              ],
+            },
+            { type: 'text', id: 'risks', title: 'Risks', body: '**Market risk** — value can fall.' },
+          ],
+          right: [
+            {
+              type: 'keyFactGroup',
+              id: 'risk-liquidity',
+              title: 'Risk & liquidity profile',
+              items: [
+                { label: 'Portfolio manager', value: { kind: 'text', text: 'MacKay Shields LLC' } },
+                { label: 'Liquidity', value: { kind: 'text', text: 'Daily' }, visibility: 'whitelisted' },
+              ],
+            },
           ],
         },
         { type: 'section', id: 'contracts', ref: 'smartContracts', visibility: 'public' },

--- a/src/types/poolMetadata.ts
+++ b/src/types/poolMetadata.ts
@@ -596,8 +596,12 @@ export type SectionRefBlock = {
 export type LayoutItem = ContentBlock | SectionRefBlock
 
 export type Factsheet = {
-  /** Top region, left column, ordered (authored blocks + app section refs e.g. `onchainMetrics`). */
-  body: LayoutItem[]
+  /**
+   * Top region, left column, ordered (authored blocks + app section refs e.g. `onchainMetrics`).
+   * Excludes `ColumnsBlock` (already a two-column layout); `columns` is `sections`-only, enforced
+   * here at compile time and in {@link parsePoolMetadataV2} at runtime.
+   */
+  body: Array<Exclude<LayoutItem, ColumnsBlock>>
   /** Top region, right column, ordered groups of key facts (groups only, no bare key facts). */
   keyFacts: KeyFactGroup[]
   /** Full-width region below, ordered. Omit to let the app render its default sections. */

--- a/src/types/poolMetadata.ts
+++ b/src/types/poolMetadata.ts
@@ -467,12 +467,26 @@ export type ChartBlock = BlockBase & {
 
 export type ImageBlock = BlockBase & { type: 'image'; file: FileType; alt?: string; caption?: string }
 
+/**
+ * Issuer-chosen framing for a KPI group. Omit to use the app default.
+ * - `boxed` — one bordered container around the whole group.
+ * - `cards` — each item in its own bordered tile.
+ * - `plain` — no framing.
+ */
+export type KpiVariant = 'plain' | 'boxed' | 'cards'
+
 export type KpiGroupBlock = BlockBase & {
   type: 'kpiGroup'
   columns?: 1 | 2 | 3 | 4
+  /** Issuer-chosen framing; the app picks a sensible default when omitted. */
+  variant?: KpiVariant
   items: Array<{
     label: string
     value: string
+    /** Optional change badge, e.g. '-0.47%'; colored by `trend`. */
+    delta?: string
+    /** Optional comparison subline rendered under the value, e.g. 'vs 6.96%'. */
+    secondary?: string
     tooltip?: string
     trend?: 'up' | 'down' | 'neutral'
     visibility?: Visibility
@@ -520,6 +534,41 @@ export type AccordionBlock = BlockBase & {
   items: Array<{ title: string; block: TabBlock; defaultOpen?: boolean }>
 }
 
+/**
+ * Left:right width ratio for a {@link ColumnsBlock}; default '1:1'. Closed set, SDK-validated.
+ */
+export type ColumnRatio = '1:1' | '3:2' | '2:1' | '2:3' | '1:2'
+
+/**
+ * A two-column section container for the full-width `sections` region (not `body`, which is already
+ * two-column). One level deep: no nested `columns`, and no app-owned `section` refs inside a column.
+ * `keyFactGroup` is allowed inside a column (e.g. a right-hand "Risk & liquidity profile" fact list).
+ * Stacks to a single column on mobile (left then right) — app-owned responsive behavior.
+ */
+export type ColumnsBlock = BlockBase & {
+  type: 'columns'
+  ratio?: ColumnRatio
+  left: ColumnChild[]
+  right: ColumnChild[]
+}
+
+/**
+ * Allowed inside a column: any content block except a nested `columns` (and no app-owned `section`
+ * refs), plus `keyFactGroup`. Listed explicitly rather than `Exclude<ContentBlock, ColumnsBlock>` to
+ * avoid a recursive type-alias cycle (`ContentBlock` includes `ColumnsBlock`).
+ */
+export type ColumnChild =
+  | TextBlock
+  | TableBlock
+  | ChartBlock
+  | ImageBlock
+  | KpiGroupBlock
+  | TabGroupBlock
+  | LiveTableBlock
+  | DocumentsBlock
+  | AccordionBlock
+  | KeyFactGroup
+
 export type ContentBlock =
   | TextBlock
   | TableBlock
@@ -530,6 +579,7 @@ export type ContentBlock =
   | LiveTableBlock
   | DocumentsBlock
   | AccordionBlock
+  | ColumnsBlock
 
 /** A pointer to one of the closed, app-owned section units. */
 export type SectionRefBlock = {

--- a/src/utils/poolMetadataMigration.test.ts
+++ b/src/utils/poolMetadataMigration.test.ts
@@ -592,6 +592,13 @@ describe('parsePoolMetadataV2', () => {
     expect(() => parsePoolMetadataV2(bad)).to.throw(/ratio/)
   })
 
+  it('rejects a columns block with a non-array left/right', () => {
+    const bad = clone(mockPoolMetadataV2)
+    const cols = bad.pool.factsheet!.sections!.find((b) => b.id === 'risk') as Record<string, unknown>
+    cols.left = 'not-an-array'
+    expect(() => parsePoolMetadataV2(bad)).to.throw(/left must be an array/)
+  })
+
   it('rejects an invalid kpiGroup variant', () => {
     const bad = clone(mockPoolMetadataV2)
     const kpi = bad.pool.factsheet!.body.find((b) => b.id === 'kpis') as Record<string, unknown>

--- a/src/utils/poolMetadataMigration.test.ts
+++ b/src/utils/poolMetadataMigration.test.ts
@@ -565,6 +565,47 @@ describe('parsePoolMetadataV2', () => {
     expect(() => parsePoolMetadataV2(bad)).to.throw(/indexer metric/)
   })
 
+  it('rejects a columns block in the body region (sections-only)', () => {
+    const bad = clone(mockPoolMetadataV2)
+    bad.pool.factsheet!.body.push({ type: 'columns', id: 'cols-in-body', left: [], right: [] } as never)
+    expect(() => parsePoolMetadataV2(bad)).to.throw(/sections region/)
+  })
+
+  it('rejects a nested columns block inside a column', () => {
+    const bad = clone(mockPoolMetadataV2)
+    const cols = bad.pool.factsheet!.sections!.find((b) => b.id === 'risk') as { left: Record<string, unknown>[] }
+    cols.left.push({ type: 'columns', id: 'nested', left: [], right: [] })
+    expect(() => parsePoolMetadataV2(bad)).to.throw(/nested/)
+  })
+
+  it('rejects an app-owned section ref inside a column', () => {
+    const bad = clone(mockPoolMetadataV2)
+    const cols = bad.pool.factsheet!.sections!.find((b) => b.id === 'risk') as { right: Record<string, unknown>[] }
+    cols.right.push({ type: 'section', id: 'sc', ref: 'smartContracts' })
+    expect(() => parsePoolMetadataV2(bad)).to.throw(/section refs are not allowed inside a column/)
+  })
+
+  it('rejects an invalid columns ratio', () => {
+    const bad = clone(mockPoolMetadataV2)
+    const cols = bad.pool.factsheet!.sections!.find((b) => b.id === 'risk') as Record<string, unknown>
+    cols.ratio = '5:1'
+    expect(() => parsePoolMetadataV2(bad)).to.throw(/ratio/)
+  })
+
+  it('rejects an invalid kpiGroup variant', () => {
+    const bad = clone(mockPoolMetadataV2)
+    const kpi = bad.pool.factsheet!.body.find((b) => b.id === 'kpis') as Record<string, unknown>
+    kpi.variant = 'fancy'
+    expect(() => parsePoolMetadataV2(bad)).to.throw(/variant/)
+  })
+
+  it('rejects a non-string kpiGroup item delta', () => {
+    const bad = clone(mockPoolMetadataV2)
+    const kpi = bad.pool.factsheet!.body.find((b) => b.id === 'kpis') as { items: Record<string, unknown>[] }
+    kpi.items[0]!.delta = 123
+    expect(() => parsePoolMetadataV2(bad)).to.throw(/delta/)
+  })
+
   it('tolerates a pool with no factsheet', () => {
     const minimal: PoolMetadataV2 = {
       version: 2,

--- a/src/utils/poolMetadataMigration.test.ts
+++ b/src/utils/poolMetadataMigration.test.ts
@@ -606,6 +606,13 @@ describe('parsePoolMetadataV2', () => {
     expect(() => parsePoolMetadataV2(bad)).to.throw(/delta/)
   })
 
+  it('rejects a non-string kpiGroup item secondary', () => {
+    const bad = clone(mockPoolMetadataV2)
+    const kpi = bad.pool.factsheet!.body.find((b) => b.id === 'kpis') as { items: Record<string, unknown>[] }
+    kpi.items[0]!.secondary = 123
+    expect(() => parsePoolMetadataV2(bad)).to.throw(/secondary/)
+  })
+
   it('tolerates a pool with no factsheet', () => {
     const minimal: PoolMetadataV2 = {
       version: 2,

--- a/src/utils/poolMetadataMigration.ts
+++ b/src/utils/poolMetadataMigration.ts
@@ -423,9 +423,12 @@ const CONTENT_BLOCK_TYPES = new Set([
   'liveTable',
   'documents',
   'accordion',
+  'columns',
 ])
 const TAB_BLOCK_TYPES = new Set(['text', 'table', 'chart', 'kpiGroup'])
 const KPI_TRENDS = new Set(['up', 'down', 'neutral'])
+const KPI_VARIANTS = new Set(['plain', 'boxed', 'cards'])
+const COLUMN_RATIOS = new Set(['1:1', '3:2', '2:1', '2:3', '1:2'])
 
 function fail(message: string): never {
   throw new Error(`pool metadata v2: ${message}`)
@@ -682,11 +685,16 @@ function validateContentBlock(block: Record<string, unknown>, type: string, wher
       if (block.columns !== undefined && ![1, 2, 3, 4].includes(block.columns as number)) {
         fail(`${where}.columns must be 1, 2, 3 or 4`)
       }
+      if (block.variant !== undefined && !KPI_VARIANTS.has(block.variant as string)) {
+        fail(`${where}.variant must be one of plain, boxed, cards`)
+      }
       if (!Array.isArray(block.items)) fail(`${where}.items must be an array`)
       block.items.forEach((item, index) => {
         if (!isObject(item)) fail(`${where}.items[${index}] must be an object`)
         assertString(item.label, `${where}.items[${index}].label`)
         assertString(item.value, `${where}.items[${index}].value`)
+        if (item.delta !== undefined) assertString(item.delta, `${where}.items[${index}].delta`)
+        if (item.secondary !== undefined) assertString(item.secondary, `${where}.items[${index}].secondary`)
         if (item.trend !== undefined && !KPI_TRENDS.has(item.trend as string)) {
           fail(`${where}.items[${index}].trend is invalid`)
         }
@@ -732,9 +740,40 @@ function validateContentBlock(block: Record<string, unknown>, type: string, wher
       })
       break
     }
+    case 'columns': {
+      if (block.ratio !== undefined && !COLUMN_RATIOS.has(block.ratio as string)) {
+        fail(`${where}.ratio is invalid (expected one of 1:1, 3:2, 2:1, 2:3, 1:2)`)
+      }
+      for (const side of ['left', 'right'] as const) {
+        if (!Array.isArray(block[side])) fail(`${where}.${side} must be an array`)
+        ;(block[side] as unknown[]).forEach((child, index) => validateColumnChild(child, `${where}.${side}[${index}]`))
+      }
+      break
+    }
     default:
       fail(`${where} has an unknown block type "${type}"`)
   }
+}
+
+/**
+ * Validates a child of a {@link ColumnsBlock} column: any content block except a nested `columns`,
+ * plus `keyFactGroup`. App-owned `section` refs are not allowed (they stay full-width).
+ */
+function validateColumnChild(value: unknown, where: string): void {
+  if (!isObject(value)) fail(`${where} must be an object`)
+  if (typeof value.type !== 'string') fail(`${where} is missing a string \`type\``)
+  if (value.type === 'keyFactGroup') {
+    validateKeyFactGroup(value, where)
+    return
+  }
+  if (value.type === 'section') fail(`${where}: app-owned section refs are not allowed inside a column`)
+  if (value.type === 'columns') fail(`${where}: columns cannot be nested`)
+  if (!CONTENT_BLOCK_TYPES.has(value.type)) fail(`${where} has an unknown block type "${String(value.type)}"`)
+  assertString(value.id, `${where}.id`)
+  if (value.title !== undefined) assertString(value.title, `${where}.title`)
+  if (value.subtitle !== undefined) assertString(value.subtitle, `${where}.subtitle`)
+  assertVisibility(value.visibility, where)
+  validateContentBlock(value, value.type, where)
 }
 
 /** Validates a leaf block nested in a `tabGroup` tab or `accordion` item (the {@link TabBlock} set). */
@@ -749,7 +788,11 @@ function validateTabBlock(value: unknown, where: string): void {
   validateContentBlock(value, value.type, where)
 }
 
-function validateLayoutItem(item: unknown, where: string): void {
+/**
+ * `allowColumns` is true only for the full-width `sections` region. The top `body` is already a
+ * two-column layout, so a `columns` block there is rejected.
+ */
+function validateLayoutItem(item: unknown, where: string, allowColumns = false): void {
   if (!isObject(item)) fail(`${where} must be an object`)
   if (typeof item.type !== 'string') fail(`${where} is missing a string \`type\``)
   assertString(item.id, `${where}.id`)
@@ -762,6 +805,9 @@ function validateLayoutItem(item: unknown, where: string): void {
       fail(`${where} has an invalid section ref "${String(item.ref)}"`)
     }
     return
+  }
+  if (item.type === 'columns' && !allowColumns) {
+    fail(`${where}: a 'columns' block is only allowed in the full-width sections region`)
   }
   if (!CONTENT_BLOCK_TYPES.has(item.type)) {
     fail(`${where} has an unknown block type "${item.type}"`)
@@ -777,7 +823,7 @@ function validateFactsheet(factsheet: unknown): void {
   factsheet.keyFacts.forEach((group, index) => validateKeyFactGroup(group, `pool.factsheet.keyFacts[${index}]`))
   if (factsheet.sections !== undefined) {
     if (!Array.isArray(factsheet.sections)) fail('`pool.factsheet.sections` must be an array')
-    factsheet.sections.forEach((item, index) => validateLayoutItem(item, `pool.factsheet.sections[${index}]`))
+    factsheet.sections.forEach((item, index) => validateLayoutItem(item, `pool.factsheet.sections[${index}]`, true))
   }
 }
 

--- a/src/utils/poolMetadataMigration.ts
+++ b/src/utils/poolMetadataMigration.ts
@@ -197,7 +197,7 @@ function buildFactsheet(
     })
   }
 
-  const body: LayoutItem[] = []
+  const body: Factsheet['body'] = []
   if (issuer.description) {
     // Overview card: logo and the "Factsheet" link button are added only when their source field
     // exists, so a missing logo / executiveSummary degrades to a plain card (never a broken one).

--- a/src/utils/poolMetadataMigration.ts
+++ b/src/utils/poolMetadataMigration.ts
@@ -755,6 +755,14 @@ function validateContentBlock(block: Record<string, unknown>, type: string, wher
   }
 }
 
+/** Validates the envelope every layout/column block shares: id, optional title/subtitle, visibility. */
+function validateBlockEnvelope(value: Record<string, unknown>, where: string): void {
+  assertString(value.id, `${where}.id`)
+  if (value.title !== undefined) assertString(value.title, `${where}.title`)
+  if (value.subtitle !== undefined) assertString(value.subtitle, `${where}.subtitle`)
+  assertVisibility(value.visibility, where)
+}
+
 /**
  * Validates a child of a {@link ColumnsBlock} column: any content block except a nested `columns`,
  * plus `keyFactGroup`. App-owned `section` refs are not allowed (they stay full-width).
@@ -769,10 +777,7 @@ function validateColumnChild(value: unknown, where: string): void {
   if (value.type === 'section') fail(`${where}: app-owned section refs are not allowed inside a column`)
   if (value.type === 'columns') fail(`${where}: columns cannot be nested`)
   if (!CONTENT_BLOCK_TYPES.has(value.type)) fail(`${where} has an unknown block type "${String(value.type)}"`)
-  assertString(value.id, `${where}.id`)
-  if (value.title !== undefined) assertString(value.title, `${where}.title`)
-  if (value.subtitle !== undefined) assertString(value.subtitle, `${where}.subtitle`)
-  assertVisibility(value.visibility, where)
+  validateBlockEnvelope(value, where)
   validateContentBlock(value, value.type, where)
 }
 
@@ -795,10 +800,7 @@ function validateTabBlock(value: unknown, where: string): void {
 function validateLayoutItem(item: unknown, where: string, allowColumns = false): void {
   if (!isObject(item)) fail(`${where} must be an object`)
   if (typeof item.type !== 'string') fail(`${where} is missing a string \`type\``)
-  assertString(item.id, `${where}.id`)
-  if (item.title !== undefined) assertString(item.title, `${where}.title`)
-  if (item.subtitle !== undefined) assertString(item.subtitle, `${where}.subtitle`)
-  assertVisibility(item.visibility, where)
+  validateBlockEnvelope(item, where)
 
   if (item.type === 'section') {
     if (typeof item.ref !== 'string' || !SECTION_REFS.has(item.ref as SectionRef)) {


### PR DESCRIPTION
## Summary

Additive extension to the v2 factsheet content model: a **two-column section container** and **richer KPI panels**. Implements centrifuge/apps-invest#232. The SDK only carries and validates the content; layout, responsive behavior and framing are the invest app's job.

## What's in here

- **`ColumnsBlock`** (`type: 'columns'`): `left`/`right` arrays of `ColumnChild`, with an optional `ColumnRatio` (`'1:1' | '3:2' | '2:1' | '2:3' | '1:2'`, default `1:1`). Constraints, all SDK-validated:
  - allowed in the full-width `sections` region only (rejected in `body`, which is already two-column);
  - one level deep (no nested `columns`);
  - no app-owned `section` refs inside a column;
  - `keyFactGroup` is allowed inside a column (so a right column can be a label/value fact list).
- **`kpiGroup`**: optional item `delta` (change badge, colored by `trend`) and `secondary` (comparison subline), plus a block-level `variant` (`'plain' | 'boxed' | 'cards'`). The boxed-vs-tiles framing is issuer-selectable via `variant`; the default when omitted stays app-owned.
- **Validation** (`parsePoolMetadataV2`): container child types, sections-only placement, no nesting, closed `ratio` set; new `delta`/`secondary` strings; `variant` against the closed set.
- **Tests/mock**: the v2 mock now includes a `columns` section (left KPI + text, right `keyFactGroup`) and a kpiGroup with `delta`/`secondary`/`variant`, so the accept path is covered by the existing "every block type" test; added reject tests for columns-in-body, nested columns, a section ref inside a column, an invalid ratio, an invalid variant, and a non-string delta.

## Compatibility

Additive and back-compatible. No schema-shape break; reads unaffected; existing documents unaffected.

## Test status

`pnpm build` / `pnpm test:unit` were **not run in this environment** (no `node_modules`/deps here); the tests mirror the existing `clone(mockPoolMetadataV2)` + `expect(...).to.throw(/…/)` patterns and run in CI.

Ref: centrifuge/apps-invest#232
