### PR TITLE
fix(pool): don't re-pin metadata on a share-class rename; partial-merge SC metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@centrifuge/sdk",
-  "version": "1.21.1",
+  "version": "1.22.0",
   "description": "",
   "homepage": "https://github.com/centrifuge/sdk/tree/main#readme",
   "author": "",

--- a/src/entities/Pool.ts
+++ b/src/entities/Pool.ts
@@ -704,11 +704,21 @@ export class Pool extends Entity {
         ShareClassId.from(poolDetails.id, existingShareClassesCount + index + 1)
       )
 
-      // Determine if we need to update metadata
+      // Determine if we need to re-pin metadata. A share-class rename (tokenName/symbolName) is
+      // on-chain only (updateShareClassMetadata) and is NOT part of the pinned JSON, so it must not
+      // trigger a re-pin on its own. Only re-pin when metadata content actually changes: pool-level
+      // input, a new share class, or a share-class metadata field (minInvestment/apyPercentage/apy/
+      // defaultAccounts) is provided on an updated share class.
       const hasMetadataInput = metadataInput !== null && Object.keys(metadataInput).length > 0
       const hasNewShareClasses = addedShareClasses.length > 0
-      const hasUpdatedShareClasses = updatedShareClasses.length > 0
-      const shouldUpdateMetadata = hasMetadataInput || hasNewShareClasses || hasUpdatedShareClasses
+      const hasUpdatedShareClassMetadata = updatedShareClasses.some(
+        (sc) =>
+          sc.minInvestment !== undefined ||
+          sc.apyPercentage !== undefined ||
+          sc.apy !== undefined ||
+          sc.defaultAccounts !== undefined
+      )
+      const shouldUpdateMetadata = hasMetadataInput || hasNewShareClasses || hasUpdatedShareClassMetadata
 
       let cid: string | null = null
 
@@ -794,15 +804,17 @@ export class Pool extends Entity {
           shareClasses: { ...baseMetadata.shareClasses, ...newShareClassesById },
         }
 
+        // Partial merge: only override keys that were actually provided, so omitting a field
+        // preserves the stored value instead of dropping it (callers need not echo existing values).
         updatedShareClasses.forEach((sc) => {
           const id = sc.id.toString()
 
           formattedMetadata.shareClasses[id] = {
             ...formattedMetadata.shareClasses[id],
-            minInitialInvestment: sc.minInvestment,
-            apyPercentage: sc.apyPercentage,
-            apy: sc.apy,
-            defaultAccounts: sc.defaultAccounts,
+            ...(sc.minInvestment !== undefined ? { minInitialInvestment: sc.minInvestment } : {}),
+            ...(sc.apyPercentage !== undefined ? { apyPercentage: sc.apyPercentage } : {}),
+            ...(sc.apy !== undefined ? { apy: sc.apy } : {}),
+            ...(sc.defaultAccounts !== undefined ? { defaultAccounts: sc.defaultAccounts } : {}),
           }
         })
 


### PR DESCRIPTION
## Summary

Fixes #489. Renaming a share class (`tokenName`/`symbolName`) via `pool.update()` re-pinned the **entire** pool metadata document (new IPFS CID + on-chain `setPoolMetadata`), even though name/symbol are stored **on-chain** (`updateShareClassMetadata`) and are not part of the pinned JSON.

## Changes (`src/entities/Pool.ts`, `update()`)

1. **Decouple the on-chain rename from the re-pin.** `shouldUpdateMetadata` no longer keys off "any updated share class"; it now re-pins only when metadata content actually changes:
   - `hasMetadataInput` (pool-level input), or
   - `hasNewShareClasses`, or
   - `hasUpdatedShareClassMetadata` — an updated share class that provides `minInvestment` / `apyPercentage` / `apy` / `defaultAccounts`.

   A name/symbol-only update now emits just `updateShareClassMetadata` (the rename is still detected via `shareClassesToBeUpdated`, unchanged) with no `pinJson` / `setPoolMetadata`.

2. **Partial-merge updated share-class metadata.** The per-share-class override now sets only the keys that were provided, so omitting a field preserves the stored value instead of dropping it on re-pin. Callers no longer need to read back and echo existing values to avoid silent reverts.

## Acceptance (from #489)

- ✅ A name/symbol-only update does not change the pinned CID and emits no `setPoolMetadata`.
- ✅ Editing a share-class metadata field still re-pins, preserving all other pool + share-class fields (partial merge).
- ✅ No caller needs to echo existing share-class metadata to avoid data loss.

## Notes

- Scope kept to the required behavior. The optional standalone `ShareClass.updateName` / `Pool.renameShareClass` from the issue was **not** added: with this fix, `pool.update({}, [{ id, tokenName, symbolName }])` already emits only the on-chain rename and no re-pin, so the downstream `submitHelpers.ts` simplification (drop the metadata pass-through) works without new API surface. Happy to add the standalone method as a follow-up if preferred.
- `pnpm build` green, `pnpm test:unit` green (277). `update()` runs through the Tenderly-gated `_transact` flow (the existing Pool integration tests are `describe.skip`), so there's no non-Tenderly seam to unit-test the metadata-build path; the change is a small, self-contained logic fix verified by build + review.

## Downstream (apps-v3)

`src/components/settings/UpdateTokenModal/submitHelpers.ts` can drop the `minInvestment`/`apyPercentage`/`apy`/`defaultAccounts` pass-through and call `pool.update({}, [{ id, tokenName, symbolName }])` for a pure rename.

Fixes #489
