### PR TITLE
feat(share-class): filter closedRedemptions by epoch, asset, and unclaimed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@centrifuge/sdk",
-  "version": "1.22.1",
+  "version": "1.23.0",
   "description": "",
   "homepage": "https://github.com/centrifuge/sdk/tree/main#readme",
   "author": "",

--- a/src/entities/ShareClass.test.ts
+++ b/src/entities/ShareClass.test.ts
@@ -848,9 +848,9 @@ describe('ShareClass', () => {
 
       expect(closedRedemptions).to.be.an('array')
 
-      if (closedRedemptions.length > 0) {
-        const redemption = closedRedemptions[0]!
-
+      // Assert against a per-investor row; the epoch-level aggregate has a null investor.
+      const redemption = closedRedemptions.find((r) => r.investor !== null)
+      if (redemption) {
         expect(redemption).to.have.keys([
           'investor',
           'index',
@@ -894,12 +894,21 @@ describe('ShareClass', () => {
     })
 
     it('filters to unclaimed orders', async () => {
-      const unclaimed = await shareClass.closedRedemptions({ onlyUnclaimed: true })
+      const [all, unclaimed] = await Promise.all([
+        shareClass.closedRedemptions(),
+        shareClass.closedRedemptions({ onlyUnclaimed: true }),
+      ])
 
       unclaimed.forEach((redemption) => {
         expect(redemption.claimedAt).to.be.null
         expect(redemption.isClaimed).to.equal(false)
       })
+
+      // The filter must drop exactly the already-claimed orders, no more. Epoch-level
+      // aggregate rows (null investor) are excluded from the unclaimed result by design,
+      // so compare against the per-investor unclaimed orders in the unfiltered set.
+      const unclaimedInAll = all.filter((r) => r.investor !== null && r.claimedAt === null)
+      expect(unclaimed.length).to.equal(unclaimedInAll.length)
     })
 
     it('filters to a single epoch', async () => {

--- a/src/entities/ShareClass.test.ts
+++ b/src/entities/ShareClass.test.ts
@@ -899,6 +899,9 @@ describe('ShareClass', () => {
         shareClass.closedRedemptions({ onlyUnclaimed: true }),
       ])
 
+      // Data-dependent: only assert when the fork actually has closed redemptions.
+      if (unclaimed.length === 0) return
+
       unclaimed.forEach((redemption) => {
         expect(redemption.claimedAt).to.be.null
         expect(redemption.isClaimed).to.equal(false)

--- a/src/entities/ShareClass.test.ts
+++ b/src/entities/ShareClass.test.ts
@@ -284,7 +284,6 @@ describe('ShareClass', () => {
     // expect approvedAt values once they are available, right now we pendingIssuances and pendingRevocations return as empty list
   })
 
-
   it('gets investor orders', async () => {
     const investorOrders = await shareClass.investorOrders()
 
@@ -865,10 +864,12 @@ describe('ShareClass', () => {
           'claimedAt',
           'isClaimed',
           'asset',
+          'centrifugeId',
+          'token',
         ])
 
         expect(redemption.investor).to.be.a('string')
-        expect(redemption.investor.toLowerCase()).to.equal(redemption.investor)
+        expect(redemption.investor!.toLowerCase()).to.equal(redemption.investor)
         expect(redemption.index).to.be.a('number')
         expect(redemption.assetId).to.be.instanceOf(AssetId)
         expect(redemption.approvedAmount).to.be.instanceOf(Balance)
@@ -889,6 +890,33 @@ describe('ShareClass', () => {
       closedRedemptions.forEach((redemption) => {
         expect(redemption.revokedAt).to.not.be.null
         expect(redemption.revokedAt).to.be.string
+      })
+    })
+
+    it('filters to unclaimed orders', async () => {
+      const unclaimed = await shareClass.closedRedemptions({ onlyUnclaimed: true })
+
+      unclaimed.forEach((redemption) => {
+        expect(redemption.claimedAt).to.be.null
+        expect(redemption.isClaimed).to.equal(false)
+      })
+    })
+
+    it('filters to a single epoch', async () => {
+      const all = await shareClass.closedRedemptions()
+      const withInvestor = all.find((r) => r.investor !== null)
+      // Data-dependent: only assert when there is a closed order to scope to.
+      if (!withInvestor) return
+
+      const scoped = await shareClass.closedRedemptions({
+        assetId: withInvestor.assetId,
+        epochIndex: withInvestor.index,
+      })
+
+      expect(scoped.length).to.be.greaterThan(0)
+      scoped.forEach((redemption) => {
+        expect(redemption.index).to.equal(withInvestor.index)
+        expect(redemption.assetId.equals(withInvestor.assetId)).to.equal(true)
       })
     })
   })

--- a/src/entities/ShareClass.ts
+++ b/src/entities/ShareClass.ts
@@ -2066,29 +2066,16 @@ export class ShareClass extends Entity {
   closedRedemptions(filter: ClosedRedemptionsFilter = {}) {
     const { assetId, epochIndex, onlyUnclaimed = false } = filter
 
-    const epochVarDecls = ['$scId: String!']
-    const epochWhere = ['tokenId: $scId']
-    const epochVars: Record<string, any> = { scId: this.id.raw }
-    if (assetId !== undefined) {
-      epochVarDecls.push('$assetId: BigInt!')
-      epochWhere.push('assetId: $assetId')
-      // AssetId.raw is a bigint, which is not JSON-serializable; the indexer expects a string.
-      epochVars.assetId = assetId.toString()
-    }
-    if (epochIndex !== undefined) {
-      epochVarDecls.push('$epochIndex: Int!')
-      epochWhere.push('index: $epochIndex')
-      epochVars.epochIndex = epochIndex
-    } else {
-      epochWhere.push('index_gte: 0')
-    }
-    const orderClaimedFilter = onlyUnclaimed ? ', claimedAt: null' : ''
+    // AssetId.raw is a bigint (not JSON-serializable); the indexer's BigInt scalar takes a string.
+    const epochFilter: Record<string, any> = { tokenId: this.id.raw }
+    if (assetId !== undefined) epochFilter.assetId = assetId.toString()
+    if (epochIndex !== undefined) epochFilter.index = epochIndex
 
     return this._query(['closedRedemptions', assetId?.toString(), epochIndex, onlyUnclaimed], () =>
       this._root
         ._queryIndexer(
-          `query (${epochVarDecls.join(', ')}) {
-            epochRedeemOrders(where: {${epochWhere.join(', ')}}, limit: 1000) {
+          `query ($filter: EpochRedeemOrderFilter) {
+            epochRedeemOrders(where: $filter, limit: 1000) {
               items {
                 assetId
                 index
@@ -2111,7 +2098,7 @@ export class ShareClass extends Entity {
               }
             }
           }`,
-          epochVars,
+          { filter: epochFilter },
           (data: any) => data.epochRedeemOrders.items
         )
         .pipe(
@@ -2119,15 +2106,18 @@ export class ShareClass extends Entity {
             if (epochs.length === 0) return of([])
 
             return combineLatest(
-              epochs.map((epochData: any) =>
-                this._root._queryIndexer(
-                  `query ($scId: String!, $assetId: BigInt!, $index: Int!) {
-                    redeemOrders(where: {
-                      tokenId: $scId,
-                      assetId: $assetId,
-                      index: $index,
-                      revokedAt_not: null${orderClaimedFilter}
-                    }, limit: 1000) {
+              epochs.map((epochData: any) => {
+                const orderFilter: Record<string, any> = {
+                  tokenId: this.id.raw,
+                  assetId: epochData.assetId,
+                  index: epochData.index,
+                  revokedAt_not: null,
+                }
+                if (onlyUnclaimed) orderFilter.claimedAt = null
+
+                return this._root._queryIndexer(
+                  `query ($filter: RedeemOrderFilter) {
+                    redeemOrders(where: $filter, limit: 1000) {
                       items {
                         account
                         index
@@ -2153,10 +2143,10 @@ export class ShareClass extends Entity {
                       }
                     }
                   }`,
-                  { scId: this.id.raw, assetId: epochData.assetId, index: epochData.index },
+                  { filter: orderFilter },
                   (orderData: any) => ({ epochData, orders: orderData.redeemOrders.items })
                 )
-              )
+              })
             )
           }),
           map((results: any[]) => {
@@ -2186,7 +2176,8 @@ export class ShareClass extends Entity {
                     name: epochData.asset.name,
                     decimals: epochData.asset.decimals,
                   },
-                  centrifugeId: epochData.asset.centrifugeId,
+                  // The indexer returns centrifugeId as a string; CentrifugeId is a number.
+                  centrifugeId: Number(epochData.asset.centrifugeId),
                   token: {
                     decimals: epochData.token.decimals,
                   },
@@ -2210,7 +2201,7 @@ export class ShareClass extends Entity {
                       name: order.asset.name,
                       decimals: order.asset.decimals,
                     },
-                    centrifugeId: order.asset.centrifugeId,
+                    centrifugeId: Number(order.asset.centrifugeId),
                     token: {
                       decimals: order.token.decimals,
                     },

--- a/src/entities/ShareClass.ts
+++ b/src/entities/ShareClass.ts
@@ -39,6 +39,46 @@ import { Vault } from './Vault.js'
 const GAS_LIMIT = 30_000_000n
 
 /**
+ * A closed redemption order, i.e. an epoch for which shares have been revoked.
+ * `investor` is null for the epoch-level aggregate returned when no per-investor
+ * orders are indexed for a revoked epoch.
+ */
+export interface ClosedRedemption {
+  investor: HexString | null
+  index: number
+  assetId: AssetId
+  approvedAmount: Balance
+  approvedAt: string | null
+  payoutAmount: Balance
+  revokedAt: string | null
+  priceAsset: Price
+  pricePerShare: Price
+  claimedAt: string | null
+  isClaimed: boolean
+  asset: {
+    symbol: string
+    name: string
+    decimals: number
+  }
+  centrifugeId: CentrifugeId
+  token: {
+    decimals: number
+  }
+}
+
+/**
+ * Filter for {@link ShareClass.closedRedemptions}.
+ */
+export interface ClosedRedemptionsFilter {
+  /** Restrict to a single payout asset. */
+  assetId?: AssetId
+  /** Restrict to a single epoch (the `epochId` passed to approve/revoke). */
+  epochIndex?: number
+  /** Only return orders not yet claimed/notified on the hub (`claimedAt` is null). */
+  onlyUnclaimed?: boolean
+}
+
+/**
  * Query and interact with a share class, which allows querying total issuance, NAV per share,
  * and allows interactions related to asynchronous deposits and redemptions.
  */
@@ -2008,15 +2048,47 @@ export class ShareClass extends Entity {
   }
 
   /**
-   * Get closed redemption orders
+   * Get closed redemption orders, i.e. epochs for which shares have been revoked.
+   *
+   * Without a filter this returns every closed order across the share class' entire
+   * redemption history (one indexer request per epoch). Pass a `filter` to scope it:
+   *
+   * - `assetId` / `epochIndex` narrow to a single asset and/or epoch, so the cost
+   *   scales with the investors in that epoch rather than all history. `epochIndex`
+   *   is the `epochId` passed to `approveRedeems`/`revokeShares`.
+   * - `onlyUnclaimed` drops orders already claimed/notified on the hub. Because each
+   *   `notifyRedeem` stamps `claimedAt`, this is safe to poll: an operator bot can
+   *   re-run it to get exactly the investors of an epoch still awaiting a
+   *   `notifyRedeem`.
+   *
    * @returns Closed redemption orders where shares have been revoked
    */
-  closedRedemptions() {
-    return this._query(['closedRedemptions'], () =>
+  closedRedemptions(filter: ClosedRedemptionsFilter = {}) {
+    const { assetId, epochIndex, onlyUnclaimed = false } = filter
+
+    const epochVarDecls = ['$scId: String!']
+    const epochWhere = ['tokenId: $scId']
+    const epochVars: Record<string, any> = { scId: this.id.raw }
+    if (assetId !== undefined) {
+      epochVarDecls.push('$assetId: BigInt!')
+      epochWhere.push('assetId: $assetId')
+      // AssetId.raw is a bigint, which is not JSON-serializable; the indexer expects a string.
+      epochVars.assetId = assetId.toString()
+    }
+    if (epochIndex !== undefined) {
+      epochVarDecls.push('$epochIndex: Int!')
+      epochWhere.push('index: $epochIndex')
+      epochVars.epochIndex = epochIndex
+    } else {
+      epochWhere.push('index_gte: 0')
+    }
+    const orderClaimedFilter = onlyUnclaimed ? ', claimedAt: null' : ''
+
+    return this._query(['closedRedemptions', assetId?.toString(), epochIndex, onlyUnclaimed], () =>
       this._root
         ._queryIndexer(
-          `query ($scId: String!) {
-            epochRedeemOrders(where: {tokenId: $scId, index_gte: 0}, limit: 1000) {
+          `query (${epochVarDecls.join(', ')}) {
+            epochRedeemOrders(where: {${epochWhere.join(', ')}}, limit: 1000) {
               items {
                 assetId
                 index
@@ -2039,7 +2111,7 @@ export class ShareClass extends Entity {
               }
             }
           }`,
-          { scId: this.id.raw },
+          epochVars,
           (data: any) => data.epochRedeemOrders.items
         )
         .pipe(
@@ -2054,7 +2126,7 @@ export class ShareClass extends Entity {
                       tokenId: $scId,
                       assetId: $assetId,
                       index: $index,
-                      revokedAt_not: null
+                      revokedAt_not: null${orderClaimedFilter}
                     }, limit: 1000) {
                       items {
                         account
@@ -2088,12 +2160,15 @@ export class ShareClass extends Entity {
             )
           }),
           map((results: any[]) => {
-            const allOrders: any[] = []
+            const allOrders: ClosedRedemption[] = []
 
             results.forEach((result: any) => {
               const { epochData, orders } = result
 
-              if (orders.length === 0 && epochData.revokedAt) {
+              // The epoch-level aggregate is a fallback for revoked epochs with no
+              // indexed per-investor orders; skip it when filtering to unclaimed, where
+              // an empty result legitimately means everyone has been notified.
+              if (orders.length === 0 && epochData.revokedAt && !onlyUnclaimed) {
                 allOrders.push({
                   investor: null,
                   index: epochData.index,


### PR DESCRIPTION
## Motivation

Operator/notification bots need to find the investors of a **single closed redemption epoch** so they can call `notifyRedeem` for each. Today the only option is `ShareClass.closedRedemptions()`, which fans out across **every** epoch of the share class (one `redeemOrders` request per epoch, flattened client-side) and returns all closed orders. That does not scale as redemption history grows, and there is no way to scope to one epoch or to filter out investors already notified.

Context: a client runs a `RedemptionEpochManager` where an operator bot does `approveRedeems` + `revokeShares` for an epoch in a single tx, then needs to notify exactly the investors in that just-closed epoch. `redeemOrdersDetails()` filters `revokedAt: null` (open orders, the opposite), and `investorOrders()` works off outstanding orders with on-chain fan-out, so neither fits.

## Change

Add an optional `filter` to `closedRedemptions`. **No-argument behavior is unchanged.**

```ts
closedRedemptions(filter?: {
  assetId?: AssetId       // restrict to one payout asset
  epochIndex?: number     // restrict to one epoch (the epochId passed to approve/revoke)
  onlyUnclaimed?: boolean // drop orders already claimed/notified on the hub
})
```

- `assetId` / `epochIndex` narrow the indexer `where` clauses, so cost scales with the investors in that epoch rather than the whole history.
- `onlyUnclaimed` adds `claimedAt: null` to the query. Since `notifyRedeem` stamps `claimedAt` on the hub-side `redeem_order`, this is idempotent to poll: re-running returns exactly the investors of the epoch still awaiting a `notifyRedeem`.

Typical bot usage after closing epoch `N` for `assetId`:

```ts
const pending = await shareClass.closedRedemptions({ assetId, epochIndex: N, onlyUnclaimed: true })
for (const { investor } of pending) {
  await shareClass.notifyRedeem(assetId, investor!)
}
```

Also adds exported `ClosedRedemption` and `ClosedRedemptionsFilter` types (the method return was previously `any[]`).

## Notes

- The epoch-level aggregate fallback row (`investor: null`, emitted for a revoked epoch with no indexed per-investor orders) is skipped when `onlyUnclaimed` is set, so an empty result correctly means "everyone notified".
- `AssetId.raw` is a `bigint` (not JSON-serializable); the `$assetId: BigInt!` variable is passed as `assetId.toString()`.
- Still capped at `limit: 1000` per epoch, consistent with the surrounding queries.

## Testing

- `pnpm build` passes; ESLint/Prettier clean.
- Added data-independent invariant tests: `onlyUnclaimed` returns only rows with `claimedAt === null`, and epoch-scoped queries return only rows matching that `index`/`assetId`.