### PR TITLE
fix: estimate the fee(crosschainTransferShares)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@centrifuge/sdk",
-  "version": "1.23.3",
+  "version": "1.23.4",
   "description": "",
   "homepage": "https://github.com/centrifuge/sdk/tree/main#readme",
   "author": "",

--- a/src/entities/ShareClass.test.ts
+++ b/src/entities/ShareClass.test.ts
@@ -1,10 +1,13 @@
 import { expect } from 'chai'
 import { firstValueFrom, lastValueFrom, skip, skipWhile, toArray } from 'rxjs'
-import { parseAbi } from 'viem'
+import sinon from 'sinon'
+import { decodeFunctionData, parseAbi } from 'viem'
 import { ABI } from '../abi/index.js'
+import { Centrifuge } from '../Centrifuge.js'
 import { context } from '../tests/setup.js'
 import { randomAddress } from '../tests/utils.js'
 import { AccountType } from '../types/holdings.js'
+import { MessageType } from '../types/transaction.js'
 import { Balance, Price } from '../utils/BigInt.js'
 import { doTransaction } from '../utils/transaction.js'
 import { AssetId, PoolId, ShareClassId } from '../utils/types.js'
@@ -930,6 +933,85 @@ describe('ShareClass', () => {
         expect(redemption.index).to.equal(withInvestor.index)
         expect(redemption.assetId.equals(withInvestor.assetId)).to.equal(true)
       })
+    })
+  })
+
+  describe('crosschainTransferShares fee lane', () => {
+    const signingAddress = randomAddress()
+    const hubPoolId = PoolId.from(1, 1)
+    const hubScId = ShareClassId.from(hubPoolId, 1)
+
+    // Stubs the plumbing around `crosschainTransferShares` so we can inspect
+    // the fee estimate and the broadcast call without a fork. `_transact` is
+    // stubbed to drain the async generator with a fake context, which is what
+    // triggers `wrapTransaction`'s estimate + send.
+    function stubTransfer(fee: bigint) {
+      const centrifuge = new Centrifuge({ environment: 'testnet' })
+      const spoke = randomAddress()
+      const estimate = sinon.stub().resolves(fee)
+      const sendTransaction = sinon.stub().resolves('0x1')
+      sinon.stub(centrifuge as any, '_protocolAddresses').resolves({ spoke })
+      sinon.stub(centrifuge as any, '_transact').callsFake(async (cb: any, centrifugeId: any) => {
+        const gen = cb({
+          centrifugeId,
+          signingAddress,
+          isBatching: false,
+          root: { _estimate: estimate, _idToChain: async () => chainId },
+          walletClient: { sendTransaction, getChainId: async () => chainId },
+          publicClient: {
+            getCode: async () => undefined,
+            waitForTransactionReceipt: async () => ({ status: 'success' }),
+          },
+        })
+        while (!(await gen.next()).done) {
+          /* consume statuses */
+        }
+      })
+      const pool = new Pool(centrifuge, hubPoolId.raw)
+      const sc = new ShareClass(centrifuge, pool, hubScId.raw)
+      return { sc, spoke, estimate, sendTransaction }
+    }
+
+    it('estimates the source -> hub lane when bridging between two spoke chains', async () => {
+      const { sc, spoke, estimate, sendTransaction } = stubTransfer(999n)
+
+      await sc.crosschainTransferShares(2, 6, investor, 100n)
+
+      // InitiateTransferShares is routed by MessageDispatcher to the pool's hub
+      // chain (poolId.centrifugeId()), not to the destination.
+      expect(estimate.callCount).to.equal(1)
+      const [from, to, msgs] = estimate.firstCall.args
+      expect(from).to.equal(2)
+      expect(to).to.equal(1)
+      expect(msgs).to.have.length(1)
+      expect(msgs[0].type).to.equal(MessageType.InitiateTransferShares)
+      expect(msgs[0].poolId.equals(hubPoolId)).to.equal(true)
+
+      // The on-chain destination stays the actual destination chain, with the fee attached.
+      const tx = sendTransaction.firstCall.args[0]
+      expect(tx.to).to.equal(spoke)
+      expect(tx.value).to.equal(999n)
+      const decoded = decodeFunctionData({ abi: ABI.Spoke, data: tx.data })
+      expect(decoded.functionName).to.equal('crosschainTransferShares')
+      expect(decoded.args![0]).to.equal(6)
+    })
+
+    it('estimates the hub -> destination lane when the source is the hub chain', async () => {
+      const { sc, estimate, sendTransaction } = stubTransfer(555n)
+
+      await sc.crosschainTransferShares(1, 6, investor, 100n)
+
+      // From the hub, MessageDispatcher executes locally via HubHandler, which
+      // forwards ExecuteTransferShares to the destination with the same msg.value.
+      expect(estimate.callCount).to.equal(1)
+      const [from, to, msgs] = estimate.firstCall.args
+      expect(from).to.equal(1)
+      expect(to).to.equal(6)
+      expect(msgs).to.have.length(1)
+      expect(msgs[0].type).to.equal(MessageType.ExecuteTransferShares)
+      expect(msgs[0].poolId.equals(hubPoolId)).to.equal(true)
+
+      expect(sendTransaction.firstCall.args[0].value).to.equal(555n)
     })
   })
 })

--- a/src/entities/ShareClass.ts
+++ b/src/entities/ShareClass.ts
@@ -2704,6 +2704,7 @@ export class ShareClass extends Entity {
       assertCrosschainMessagingEnabled(destinationCentrifugeId)
 
       const { spoke } = await self._root._protocolAddresses(sourceCentrifugeId)
+      const hubCentrifugeId = self.pool.id.centrifugeId
 
       yield* wrapTransaction('Cross chain transfer shares', ctx, {
         contract: spoke,
@@ -2721,9 +2722,14 @@ export class ShareClass extends Entity {
             ctx.signingAddress,
           ],
         }),
-        messages: {
-          [destinationCentrifugeId]: [{ type: MessageType.InitiateTransferShares, poolId: self.pool.id }],
-        },
+        messages:
+          sourceCentrifugeId === hubCentrifugeId
+            ? {
+                [destinationCentrifugeId]: [{ type: MessageType.ExecuteTransferShares, poolId: self.pool.id }],
+              }
+            : {
+                [hubCentrifugeId]: [{ type: MessageType.InitiateTransferShares, poolId: self.pool.id }],
+              },
       })
     }, sourceCentrifugeId)
   }


### PR DESCRIPTION
## Problem

`ShareClass.crosschainTransferShares` estimates the bridge fee for the **source → destination** lane:

```ts
messages: {
  [destinationCentrifugeId]: [{ type: MessageType.InitiateTransferShares, poolId: self.pool.id }],
},
```

But on-chain, `MessageDispatcher.sendInitiateTransferShares` routes the message to the **pool's hub chain**, not the destination:

```solidity
_send(
    poolId.centrifugeId(),   // hub chain, NOT targetCentrifugeId
    MessageLib.InitiateTransferShares({ centrifugeId: targetCentrifugeId, ... }).serialize(),
    ...
```

The source → destination lane is never actually used from the source chain, so it has no adapter set wired in `MultiAdapter`, and `MultiAdapter.estimate` quotes **0 wei** for it. The SDK therefore attaches `value: 0`, and `Gateway._send` reverts with `NotEnoughGas()` because the real cost (source → hub) is nonzero.

**Impact:** every cross-chain share transfer where the destination is not the pool's hub chain reverts. E.g. from Base (hub = Ethereum): Base → BNB / Arbitrum / Avalanche / Monad all revert; Base → Ethereum only works because destination == hub.

Verified on Base mainnet (pool `281474976710662`):

| Lane | `MultiAdapter.estimate` | `quorum(dest, poolId)` |
|---|---|---|
| 2 → 1 (hub) | 1628137521299724 wei (~0.0016 ETH) | 2 |
| 2 → 6 (BNB) | **0 wei** | **0** (no adapters) |

Reproduced end-to-end in a Tenderly simulation: `Spoke.crosschainTransferShares` on Base → BNB with `value: 0` (what the SDK produces) reverts `NotEnoughGas()` at `Gateway.sol:208`; the same call with the source → hub fee attached succeeds.

## Fix

Key the fee estimate by the lane the Gateway actually charges for:

- **source ≠ hub**: estimate source → hub for `InitiateTransferShares` (the hub then forwards to the destination in a separate, hub-paid hop).
- **source == hub**: `MessageDispatcher` executes locally via `HubHandler`, which forwards `ExecuteTransferShares` to the destination with the same `msg.value` — so estimate hub → destination for `ExecuteTransferShares`.

The on-chain calldata is unchanged (`destinationCentrifugeId` stays the Spoke's destination argument); only the fee estimate lane changes. Same class of bug as #503 (registerAsset lane mismatch).

## Tests

Two regression tests in `ShareClass.test.ts` (stub-based, no fork), following the #503 pattern:
- spoke → spoke: asserts the estimate targets the hub lane with `InitiateTransferShares`, the calldata destination stays the real destination, and the fee is attached as `value`
- hub → spoke: asserts the estimate targets the destination lane with `ExecuteTransferShares`

🤖 Generated with [Claude Code](https://claude.com/claude-code)