### PR TITLE
fix: apply similar fix to apps-management for updating nav

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@centrifuge/sdk",
-  "version": "1.23.4",
+  "version": "1.23.5",
   "description": "",
   "homepage": "https://github.com/centrifuge/sdk/tree/main#readme",
   "author": "",

--- a/src/entities/ShareClass.ts
+++ b/src/entities/ShareClass.ts
@@ -38,6 +38,12 @@ import { Vault } from './Vault.js'
 
 const GAS_LIMIT = 30_000_000n
 
+// The Hub rejects a share price timestamp that isn't strictly before the on-chain block
+// timestamp. Defaulting to `new Date()` can land at or after `block.timestamp` (clock skew,
+// network latency), reverting with `CannotSetFuturePrice`. Back the default off by a small
+// buffer so callers that don't pass `updatedAt` explicitly stay safely in the past.
+const SHARE_PRICE_TIMESTAMP_SAFETY_BUFFER_SECONDS = 60
+
 /**
  * A closed redemption order, i.e. an epoch for which shares have been revoked.
  * `investor` is null for the epoch-level aggregate returned when no per-investor
@@ -690,7 +696,10 @@ export class ShareClass extends Entity {
     }, this.pool.centrifugeId)
   }
 
-  updateSharePrice(pricePerShare: Price, updatedAt = new Date()) {
+  updateSharePrice(
+    pricePerShare: Price,
+    updatedAt = new Date(Date.now() - SHARE_PRICE_TIMESTAMP_SAFETY_BUFFER_SECONDS * 1000)
+  ) {
     const self = this
     return this._transact(async function* (ctx) {
       const [{ hub }, activeNetworks] = await Promise.all([


### PR DESCRIPTION
Change (sdk/src/entities/ShareClass.ts): updateSharePrice's default updatedAt parameter now defaults to Date.now() - 60s instead of raw new Date(), mirroring the 60-second safety buffer already shipped in apps-management's navUtils.ts. This closes the gap flagged earlier — any consumer of the SDK (this app, other apps, scripts) that calls updateSharePrice(price) without explicitly passing a timestamp is now protected from the CannotSetFuturePrice revert caused by client-clock skew ahead of block.timestamp.

follows similar fix as applied in apps-management locally
https://github.com/centrifuge/apps-management/commit/fa28629067b235be2c6a49b24d018b80a33c3364#diff-5841e4434c02414424ad93dc836846b84bbe11f64e3e02cc583c97618680af8fR10-R46