### PR TITLE
docs: fix `inexerPollingInterval` typo in README config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ const cent = new Centrifuge({
   rpcUrls: {
     1: 'http://127.0.0.1:8545',
   },
-  inexerPollingInterval: 2000,
+  indexerPollingInterval: 2000,
   indexerUrl: 'http://localhost:8000',
 })
 


### PR DESCRIPTION
## Problem

The configuration example in `README.md` (line 243) spells the option **`inexerPollingInterval`**. The real option is `indexerPollingInterval`:

- declared in `src/types/index.ts:14` — `indexerPollingInterval?: number`
- consumed in `src/Centrifuge.ts:1011` — `pollInterval = this.config.indexerPollingInterval ?? 120_000`

This is worse than a cosmetic typo because it fails silently. JavaScript happily accepts the unknown key, no error is raised, and the SDK quietly falls back to the 120 s default — so a developer who copies the documented example believes they configured a 2 s poll interval and never finds out otherwise.

## Fix

One character: `inexerPollingInterval` → `indexerPollingInterval`.

`grep` confirms line 243 was the only occurrence of the misspelling anywhere in the repo, so nothing else depends on it.