### PR TITLE
fix(types): make pool asset class optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@centrifuge/sdk",
-  "version": "1.24.1",
+  "version": "2.0.0",
   "description": "",
   "homepage": "https://github.com/centrifuge/sdk/tree/main#readme",
   "author": "",

--- a/src/types/poolInput.ts
+++ b/src/types/poolInput.ts
@@ -28,7 +28,8 @@ export type IssuerDetail = {
 
 export type PoolMetadataInput = {
   poolStructure: 'revolving'
-  assetClass: 'Public credit' | 'Private credit'
+  /** Free text — 'Public credit' and 'Private credit' are the conventional values. */
+  assetClass: string
   subAssetClass: string
   shareClasses: ShareClassInput[]
   poolName: string

--- a/src/types/poolInput.ts
+++ b/src/types/poolInput.ts
@@ -28,7 +28,7 @@ export type IssuerDetail = {
 
 export type PoolMetadataInput = {
   poolStructure: 'revolving'
-  assetClass: string
+  assetClass?: 'Public credit' | 'Private credit'
   subAssetClass: string
   shareClasses: ShareClassInput[]
   poolName: string

--- a/src/types/poolInput.ts
+++ b/src/types/poolInput.ts
@@ -28,7 +28,6 @@ export type IssuerDetail = {
 
 export type PoolMetadataInput = {
   poolStructure: 'revolving'
-  /** Free text — 'Public credit' and 'Private credit' are the conventional values. */
   assetClass: string
   subAssetClass: string
   shareClasses: ShareClassInput[]

--- a/src/types/poolMetadata.ts
+++ b/src/types/poolMetadata.ts
@@ -134,7 +134,8 @@ export type PoolMetadataV1 = {
     name: string
     icon: FileType | null
     asset: {
-      class: 'Public credit' | 'Private credit'
+      /** Free text — 'Public credit' and 'Private credit' are the conventional values, but pools exist with others (e.g. 'Equity Index Fund'). */
+      class: string
       subClass: string
     }
     underlying?: {

--- a/src/types/poolMetadata.ts
+++ b/src/types/poolMetadata.ts
@@ -134,7 +134,7 @@ export type PoolMetadataV1 = {
     name: string
     icon: FileType | null
     asset: {
-      class: string
+      class?: 'Public credit' | 'Private credit'
       subClass: string
     }
     underlying?: {

--- a/src/types/poolMetadata.ts
+++ b/src/types/poolMetadata.ts
@@ -134,7 +134,6 @@ export type PoolMetadataV1 = {
     name: string
     icon: FileType | null
     asset: {
-      /** Free text — 'Public credit' and 'Private credit' are the conventional values, but pools exist with others (e.g. 'Equity Index Fund'). */
       class: string
       subClass: string
     }


### PR DESCRIPTION
## Summary

Companion to centrifuge/apps-management#1228.

`pool.asset.class` (PoolMetadata) and `PoolMetadataInput.assetClass` keep the `'Public credit' | 'Private credit'` union but become optional — pools exist without an asset class set, and the required type forced consumers into blocking validation: the management app's pool-metadata form rejected every save on such pools, preventing edits to unrelated fields.

Type-only change — no runtime behavior touched; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)