### PR TITLE
feat(types): pool asset class is a free-text string

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@centrifuge/sdk",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "",
   "homepage": "https://github.com/centrifuge/sdk/tree/main#readme",
   "author": "",

--- a/src/types/poolInput.ts
+++ b/src/types/poolInput.ts
@@ -28,7 +28,7 @@ export type IssuerDetail = {
 
 export type PoolMetadataInput = {
   poolStructure: 'revolving'
-  assetClass?: 'Public credit' | 'Private credit'
+  assetClass?: string
   subAssetClass: string
   shareClasses: ShareClassInput[]
   poolName: string

--- a/src/types/poolMetadata.ts
+++ b/src/types/poolMetadata.ts
@@ -134,7 +134,7 @@ export type PoolMetadataV1 = {
     name: string
     icon: FileType | null
     asset: {
-      class?: 'Public credit' | 'Private credit'
+      class?: string
       subClass: string
     }
     underlying?: {


### PR DESCRIPTION
## Summary

Companion to centrifuge/apps-management#1231: the management app now lets operators write any asset class, so `pool.asset.class` (PoolMetadata) and `PoolMetadataInput.assetClass` go from the optional `'Public credit' | 'Private credit'` union to optional `string`.

Type-only change; `tsc --noEmit` clean. Once released, the cast in apps-management#1231's `buildMetadataPayload.ts` can be dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)